### PR TITLE
Add MCO parameter support in the GUI

### DIFF
--- a/doc/source/api/force_wfmanager.left_side_pane.rst
+++ b/doc/source/api/force_wfmanager.left_side_pane.rst
@@ -4,6 +4,14 @@ force_wfmanager.left_side_pane package
 Submodules
 ----------
 
+force_wfmanager.left_side_pane.mco_model_view module
+----------------------------------------------------
+
+.. automodule:: force_wfmanager.left_side_pane.mco_model_view
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 force_wfmanager.left_side_pane.new_entity_modal module
 ------------------------------------------------------
 

--- a/force_wfmanager/left_side_pane/mco_model_view.py
+++ b/force_wfmanager/left_side_pane/mco_model_view.py
@@ -1,0 +1,23 @@
+from traits.api import Instance, List, Property, Str
+from traitsui.api import ModelView
+
+from force_bdss.api import BaseMCOModel, BaseMCOParameter
+
+from .view_utils import get_bundle_name
+
+
+class MCOModelView(ModelView):
+    model = Instance(BaseMCOModel)
+
+    label = Str()
+
+    mco_parameters_representation = Property(
+        List(Instance(BaseMCOParameter)),
+        depends_on="model.parameters"
+    )
+
+    def _get_mco_parameters_representation(self):
+        return self.model.parameters
+
+    def _label_default(self):
+        return get_bundle_name(self.model.bundle)

--- a/force_wfmanager/left_side_pane/mco_model_view.py
+++ b/force_wfmanager/left_side_pane/mco_model_view.py
@@ -7,10 +7,15 @@ from .view_utils import get_bundle_name
 
 
 class MCOModelView(ModelView):
+    #: MCO model
     model = Instance(BaseMCOModel)
 
+    #: Label to be used in the TreeEditor
     label = Str()
 
+    #: List of MCO parameters to be displayed in the TreeEditor, it is a
+    #: Property so that the list in the editor is synchronized with the actual
+    #: list of parameters in the MCO model
     mco_parameters_representation = Property(
         List(Instance(BaseMCOParameter)),
         depends_on="model.parameters"

--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -4,9 +4,11 @@ from traitsui.api import (View, Handler, HSplit, VGroup, UItem,
                           HGroup, ListStrEditor, InstanceEditor)
 from traitsui.list_str_adapter import ListStrAdapter
 
-from force_bdss.api import (BaseMCOModel, BaseMCOBundle,
-                            BaseDataSourceModel, BaseDataSourceBundle,
-                            BaseKPICalculatorModel, BaseKPICalculatorBundle)
+from force_bdss.api import (
+    BaseMCOModel, BaseMCOBundle,
+    BaseDataSourceModel, BaseDataSourceBundle,
+    BaseKPICalculatorModel, BaseKPICalculatorBundle,
+    BaseMCOParameter, BaseMCOParameterFactory)
 
 from .workflow_model_view import WorkflowModelView
 from .view_utils import get_bundle_name
@@ -38,6 +40,7 @@ class NewEntityModal(HasStrictTraits):
     #: which implement the create_model method
     available_bundles = Either(
         List(Instance(BaseMCOBundle)),
+        List(Instance(BaseMCOParameterFactory)),
         List(Instance(BaseDataSourceBundle)),
         List(Instance(BaseKPICalculatorBundle)),
     )
@@ -45,6 +48,7 @@ class NewEntityModal(HasStrictTraits):
     #: Selected bundle in the list
     selected_bundle = Either(
         Instance(BaseMCOBundle),
+        Instance(BaseMCOParameterFactory),
         Instance(BaseDataSourceBundle),
         Instance(BaseKPICalculatorBundle)
     )
@@ -55,6 +59,7 @@ class NewEntityModal(HasStrictTraits):
     #: Currently editable model
     current_model = Either(
         Instance(BaseMCOModel),
+        Instance(BaseMCOParameter),
         Instance(BaseDataSourceModel),
         Instance(BaseKPICalculatorModel)
     )

--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -38,17 +38,17 @@ class NewEntityModal(HasStrictTraits):
     calculator to the workflow """
     workflow = Instance(WorkflowModelView)
 
-    #: Available bundles, this class is generic and can contain any bundle
+    #: Available factories, this class is generic and can contain any factory
     #: which implement the create_model method
-    available_bundles = Either(
+    available_factories = Either(
         List(Instance(BaseMCOBundle)),
         List(Instance(BaseMCOParameterFactory)),
         List(Instance(BaseDataSourceBundle)),
         List(Instance(BaseKPICalculatorBundle)),
     )
 
-    #: Selected bundle in the list
-    selected_bundle = Either(
+    #: Selected factory in the list
+    selected_factory = Either(
         Instance(BaseMCOBundle),
         Instance(BaseMCOParameterFactory),
         Instance(BaseDataSourceBundle),
@@ -66,26 +66,26 @@ class NewEntityModal(HasStrictTraits):
         Instance(BaseKPICalculatorModel)
     )
 
-    #: Cache for created models, models are created when selecting a new bundle
-    #: and cached so that when selected_bundle change the created models are
-    #: saved
+    #: Cache for created models, models are created when selecting a new
+    #: factory and cached so that when selected_factory change the created
+    #: models are saved
     _cached_models = Dict()
 
     traits_view = View(
         VGroup(
             HSplit(
                 UItem(
-                    "available_bundles",
+                    "available_factories",
                     editor=ListStrEditor(
                         adapter=ListAdapter(),
-                        selected="selected_bundle"),
+                        selected="selected_factory"),
                 ),
                 UItem('current_model', style='custom', editor=InstanceEditor())
             ),
             HGroup(
                 UItem(
                     'add_button',
-                    enabled_when="selected_bundle is not None"
+                    enabled_when="selected_factory is not None"
                 ),
                 UItem('cancel_button')
             )
@@ -97,19 +97,19 @@ class NewEntityModal(HasStrictTraits):
         kind="livemodal"
     )
 
-    @on_trait_change("selected_bundle")
+    @on_trait_change("selected_factory")
     def update_current_model(self):
-        """ Update the current editable model when the selected bundle has
+        """ Update the current editable model when the selected factory has
         changed. The current model will be created on the fly or extracted from
         the cache if it was already created before """
-        if self.selected_bundle is None:
+        if self.selected_factory is None:
             self.current_model = None
             return
 
-        cached_model = self._cached_models.get(self.selected_bundle)
+        cached_model = self._cached_models.get(self.selected_factory)
 
         if cached_model is None:
-            cached_model = self.selected_bundle.create_model()
-            self._cached_models[self.selected_bundle] = cached_model
+            cached_model = self.selected_factory.create_model()
+            self._cached_models[self.selected_factory] = cached_model
 
         self.current_model = cached_model

--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -4,7 +4,7 @@ from traitsui.api import (View, Handler, HSplit, VGroup, UItem,
                           HGroup, ListStrEditor, InstanceEditor)
 from traitsui.list_str_adapter import ListStrAdapter
 
-from force_bdss.api import (BaseMCOModel, BaseMultiCriteriaOptimizerBundle,
+from force_bdss.api import (BaseMCOModel, BaseMCOBundle,
                             BaseDataSourceModel, BaseDataSourceBundle,
                             BaseKPICalculatorModel, BaseKPICalculatorBundle)
 
@@ -37,14 +37,14 @@ class NewEntityModal(HasStrictTraits):
     #: Available bundles, this class is generic and can contain any bundle
     #: which implement the create_model method
     available_bundles = Either(
-        List(Instance(BaseMultiCriteriaOptimizerBundle)),
+        List(Instance(BaseMCOBundle)),
         List(Instance(BaseDataSourceBundle)),
         List(Instance(BaseKPICalculatorBundle)),
     )
 
     #: Selected bundle in the list
     selected_bundle = Either(
-        Instance(BaseMultiCriteriaOptimizerBundle),
+        Instance(BaseMCOBundle),
         Instance(BaseDataSourceBundle),
         Instance(BaseKPICalculatorBundle)
     )

--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -23,11 +23,13 @@ class ListAdapter(ListStrAdapter):
 
 class ModalHandler(Handler):
     def object_add_button_changed(self, info):
+        """ Action triggered when clicking on "Add" button in the modal """
         if info.object.current_model is not None:
             info.object.workflow.add_entity(info.object.current_model)
         info.ui.dispose(True)
 
     def object_cancel_button_changed(self, info):
+        """ Action triggered when clicking on "Cancel" button in the modal """
         info.ui.dispose(False)
 
 
@@ -97,6 +99,9 @@ class NewEntityModal(HasStrictTraits):
 
     @on_trait_change("selected_bundle")
     def update_current_model(self):
+        """ Update the current editable model when the selected bundle has
+        changed. The current model will be created on the fly or extracted from
+        the cache if it was already created before """
         if self.selected_bundle is None:
             self.current_model = None
             return

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -11,7 +11,7 @@ class WorkflowModelView(ModelView):
 
     mco_representation = Property(
         List(BaseMCOModel),
-        depends_on='model.multi_criteria_optimizer')
+        depends_on='model.mco')
     data_sources_representation = Property(
         List(BaseDataSourceModel),
         depends_on='model.data_sources')
@@ -21,7 +21,7 @@ class WorkflowModelView(ModelView):
 
     def add_entity(self, entity):
         if isinstance(entity, BaseMCOModel):
-            self.model.multi_criteria_optimizer = entity
+            self.model.mco = entity
         elif isinstance(entity, BaseDataSourceModel):
             self.model.data_sources.append(entity)
         elif isinstance(entity, BaseKPICalculatorModel):
@@ -34,8 +34,8 @@ class WorkflowModelView(ModelView):
             )
 
     def _get_mco_representation(self):
-        if self.model.multi_criteria_optimizer is not None:
-            return [self.model.multi_criteria_optimizer]
+        if self.model.mco is not None:
+            return [self.model.mco]
         else:
             return []
 

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -5,12 +5,14 @@ from force_bdss.workspecs.workflow import Workflow
 from force_bdss.api import (BaseMCOModel, BaseMCOParameter,
                             BaseDataSourceModel, BaseKPICalculatorModel)
 
+from .mco_model_view import MCOModelView
+
 
 class WorkflowModelView(ModelView):
     model = Instance(Workflow)
 
     mco_representation = Property(
-        List(BaseMCOModel),
+        List(MCOModelView),
         depends_on='model.mco')
     data_sources_representation = Property(
         List(BaseDataSourceModel),
@@ -41,7 +43,7 @@ class WorkflowModelView(ModelView):
 
     def _get_mco_representation(self):
         if self.model.mco is not None:
-            return [self.model.mco]
+            return [MCOModelView(model=self.model.mco)]
         else:
             return []
 

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -8,10 +8,6 @@ from force_bdss.api import (BaseMCOModel, BaseMCOParameter,
 from .mco_model_view import MCOModelView
 
 
-class WorkflowValidityError(Exception):
-    pass
-
-
 class WorkflowModelView(ModelView):
     #: Workflow model
     model = Instance(Workflow)
@@ -42,9 +38,9 @@ class WorkflowModelView(ModelView):
 
         Raises
         ------
-        WorkflowValidityError:
+        RuntimeError:
             If the entity is an MCO parameter but no MCO is defined for the
-            Workflow
+            Workflow.
         TypeError:
             If the type of the entity is not supported by the Workflow
         """
@@ -52,7 +48,7 @@ class WorkflowModelView(ModelView):
             self.model.mco = entity
         elif isinstance(entity, BaseMCOParameter):
             if self.model.mco is None:
-                raise(WorkflowValidityError("Cannot add a parameter to the "
+                raise(RuntimeError("Cannot add a parameter to the "
                       "workflow if no MCO defined"))
 
             self.model.mco.parameters.append(entity)

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -8,26 +8,52 @@ from force_bdss.api import (BaseMCOModel, BaseMCOParameter,
 from .mco_model_view import MCOModelView
 
 
+class WorkflowValidityError(Exception):
+    pass
+
+
 class WorkflowModelView(ModelView):
+    #: Workflow model
     model = Instance(Workflow)
 
+    #: List of MCO to be displayed in the TreeEditor
     mco_representation = Property(
         List(MCOModelView),
         depends_on='model.mco')
+
+    #: List of DataSources to be displayed in the TreeEditor
     data_sources_representation = Property(
         List(BaseDataSourceModel),
         depends_on='model.data_sources')
+
+    #: List of KPI Calculators to be displayed in the TreeEditor
     kpi_calculators_representation = Property(
         List(BaseKPICalculatorModel),
         depends_on='model.kpi_calculators')
 
     def add_entity(self, entity):
+        """ Adds an element to the workflow
+
+        Parameters
+        ----------
+        entity: BaseMCOModel or BaseMCOParameter or BaseDataSourceModel or
+            BaseKPICalculatorModel
+            The element to be inserted in the Workflow
+
+        Raises
+        ------
+        WorkflowValidityError:
+            If the entity is an MCO parameter but no MCO is defined for the
+            Workflow
+        TypeError:
+            If the type of the entity is not supported by the Workflow
+        """
         if isinstance(entity, BaseMCOModel):
             self.model.mco = entity
         elif isinstance(entity, BaseMCOParameter):
             if self.model.mco is None:
-                raise("Cannot add a parameter to the workflow if no "
-                      "MCO defined")
+                raise(WorkflowValidityError("Cannot add a parameter to the "
+                      "workflow if no MCO defined"))
 
             self.model.mco.parameters.append(entity)
         elif isinstance(entity, BaseDataSourceModel):

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -2,8 +2,8 @@ from traits.api import Instance, List, Property
 from traitsui.api import ModelView
 
 from force_bdss.workspecs.workflow import Workflow
-from force_bdss.api import (BaseMCOModel, BaseDataSourceModel,
-                            BaseKPICalculatorModel)
+from force_bdss.api import (BaseMCOModel, BaseMCOParameter,
+                            BaseDataSourceModel, BaseKPICalculatorModel)
 
 
 class WorkflowModelView(ModelView):
@@ -22,6 +22,12 @@ class WorkflowModelView(ModelView):
     def add_entity(self, entity):
         if isinstance(entity, BaseMCOModel):
             self.model.mco = entity
+        elif isinstance(entity, BaseMCOParameter):
+            if self.model.mco is None:
+                raise("Cannot add a parameter to the workflow if no "
+                      "MCO defined")
+
+            self.model.mco.parameters.append(entity)
         elif isinstance(entity, BaseDataSourceModel):
             self.model.data_sources.append(entity)
         elif isinstance(entity, BaseKPICalculatorModel):

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -28,28 +28,30 @@ class WorkflowHandler(Handler):
         """ Opens a dialog for creating a MCO """
         modal = NewEntityModal(
             workflow=editor.object.workflow,
-            available_bundles=editor.object.available_mcos)
+            available_factories=editor.object.available_mco_factories)
         modal.configure_traits()
 
     def new_parameter_handler(self, editor, object):
         """ Opens a dialog for creating a parameter """
         modal = NewEntityModal(
             workflow=editor.object.workflow,
-            available_bundles=editor.object.available_parameters)
+            available_factories=editor.object.available_mco_parameter_factories
+        )
         modal.configure_traits()
 
     def new_data_source_handler(self, editor, object):
         """ Opens a dialog for creating a Data Source """
         modal = NewEntityModal(
             workflow=editor.object.workflow,
-            available_bundles=editor.object.available_data_sources)
+            available_factories=editor.object.available_data_source_factories)
         modal.configure_traits()
 
     def new_kpi_calculator_handler(self, editor, object):
         """ Opens a dialog for creating a KPI Calculator """
         modal = NewEntityModal(
             workflow=editor.object.workflow,
-            available_bundles=editor.object.available_kpi_calculators)
+            available_factories=
+            editor.object.available_kpi_calculator_factories)
         modal.configure_traits()
 
     def delete_mco_handler(self, editor, object):
@@ -219,16 +221,16 @@ class WorkflowSettings(TraitsDockPane):
     name = 'Workflow Settings'
 
     #: Available MCO bundles
-    available_mcos = List(BaseMCOBundle)
+    available_mco_factories = List(BaseMCOBundle)
 
     #: Available parameters factories
-    available_parameters = List(Instance(BaseMCOParameterFactory))
+    available_mco_parameter_factories = List(Instance(BaseMCOParameterFactory))
 
     #: Available data source bundles
-    available_data_sources = List(BaseDataSourceBundle)
+    available_data_source_factories = List(BaseDataSourceBundle)
 
     #: Available KPI calculator bundles
-    available_kpi_calculators = List(BaseKPICalculatorBundle)
+    available_kpi_calculator_factories = List(BaseKPICalculatorBundle)
 
     #: Selected MCO bundle in the list of MCOs
     selected_mco = Instance(BaseMCOBundle)
@@ -247,5 +249,5 @@ class WorkflowSettings(TraitsDockPane):
     def _workflow_default(self):
         return WorkflowModelView()
 
-    def _available_parameters_default(self):
+    def _available_mco_parameter_factories_default(self):
         return all_core_factories()

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -14,6 +14,7 @@ from force_bdss.mco.parameters.core_mco_parameters import all_core_factories
 from .view_utils import get_bundle_name
 from .new_entity_modal import NewEntityModal
 from .workflow_model_view import WorkflowModelView
+from .mco_model_view import MCOModelView
 
 # Create an empty view and menu for objects that have no data to display:
 no_view = View()
@@ -93,10 +94,11 @@ delete_kpi_calculator_action = Action(
 
 
 @provides(ITreeNode)
-class MCOAdapter(ITreeNodeAdapter):
-    """ Adapts the MCO model view to be displayed in the tree editor """
+class MCOParameterAdapter(ITreeNodeAdapter):
+    """ Adapts the MCO parameter model view to be displayed in the tree editor
+    """
     def get_label(self):
-        return get_bundle_name(self.adaptee.bundle)
+        return get_bundle_name(self.adaptee.factory)
 
     def get_view(self):
         view = self.adaptee.trait_view()
@@ -104,19 +106,7 @@ class MCOAdapter(ITreeNodeAdapter):
         return view
 
     def get_menu(self):
-        return Menu(delete_mco_action, new_parameter_action)
-
-    def allows_children(self):
-        return True
-
-    def has_children(self):
-        return True
-
-    def get_children(self):
-        return self.adaptee.parameters
-
-    def can_auto_open(self):
-        return True
+        return Menu()
 
 
 @provides(ITreeNode)
@@ -151,7 +141,7 @@ class KPICalculatorAdapter(ITreeNodeAdapter):
         return Menu(delete_kpi_calculator_action)
 
 
-register_factory(MCOAdapter, BaseMCOModel, ITreeNode)
+register_factory(MCOParameterAdapter, BaseMCOParameter, ITreeNode)
 register_factory(DataSourceAdapter, BaseDataSourceModel, ITreeNode)
 register_factory(KPICalculatorAdapter, BaseKPICalculatorModel, ITreeNode)
 
@@ -170,6 +160,20 @@ tree_editor = TreeEditor(
                  label='=MCO',
                  view=no_view,
                  menu=Menu(new_mco_action),
+                 ),
+        TreeNode(node_for=[MCOModelView],
+                 auto_open=True,
+                 children='',
+                 label='label',
+                 view=View(UItem('model', style="custom"), kind="subpanel"),
+                 menu=Menu(delete_mco_action),
+                 ),
+        TreeNode(node_for=[MCOModelView],
+                 auto_open=True,
+                 children='mco_parameters_representation',
+                 label='=Parameters',
+                 view=no_view,
+                 menu=Menu(new_parameter_action),
                  ),
         TreeNode(node_for=[WorkflowModelView],
                  auto_open=True,

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -48,10 +48,10 @@ class WorkflowHandler(Handler):
 
     def new_kpi_calculator_handler(self, editor, object):
         """ Opens a dialog for creating a KPI Calculator """
+        obj = editor.object
         modal = NewEntityModal(
-            workflow=editor.object.workflow,
-            available_factories=
-            editor.object.available_kpi_calculator_factories)
+            workflow=obj.workflow,
+            available_factories=obj.available_kpi_calculator_factories)
         modal.configure_traits()
 
     def delete_mco_handler(self, editor, object):

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -22,7 +22,8 @@ no_menu = Menu()
 
 
 class WorkflowHandler(Handler):
-    # Menu actions in the TreeEditor
+    """ Handler for the Workflow editor, this handler will take care of events
+    on the tree editor (e.g. right click on a tree element) """
     def new_mco_handler(self, editor, object):
         """ Opens a dialog for creating a MCO """
         modal = NewEntityModal(
@@ -52,17 +53,21 @@ class WorkflowHandler(Handler):
         modal.configure_traits()
 
     def delete_mco_handler(self, editor, object):
+        """ Delete the MCO from the workflow """
         editor.object.workflow.model.mco = None
 
     def delete_mco_parameter_handler(self, editor, object):
+        """ Delete one parameter from the MCO """
         workflow = editor.object.workflow.model
         workflow.mco.parameters.remove(object)
 
     def delete_data_source_handler(self, editor, object):
+        """ Delete a DataSource from the workflow """
         workflow = editor.object.workflow.model
         workflow.data_sources.remove(object)
 
     def delete_kpi_calculator_handler(self, editor, object):
+        """ Delete a KPI Calculator from the workflow """
         workflow = editor.object.workflow.model
         workflow.kpi_calculators.remove(object)
 
@@ -106,8 +111,7 @@ delete_kpi_calculator_action = Action(
 
 @provides(ITreeNode)
 class MCOParameterAdapter(ITreeNodeAdapter):
-    """ Adapts the MCO parameter model view to be displayed in the tree editor
-    """
+    """ Adapts the MCO parameter model to be displayed in the tree editor """
     def get_label(self):
         return get_bundle_name(self.adaptee.factory)
 
@@ -122,8 +126,7 @@ class MCOParameterAdapter(ITreeNodeAdapter):
 
 @provides(ITreeNode)
 class DataSourceAdapter(ITreeNodeAdapter):
-    """ Adapts the Data source model view to be displayed in the tree editor
-    """
+    """ Adapts the Data source model to be displayed in the tree editor """
     def get_label(self):
         return get_bundle_name(self.adaptee.bundle)
 
@@ -138,8 +141,7 @@ class DataSourceAdapter(ITreeNodeAdapter):
 
 @provides(ITreeNode)
 class KPICalculatorAdapter(ITreeNodeAdapter):
-    """ Adapts the KPI calculator model to be displayed in the tree editor
-    """
+    """ Adapts the KPI calculator model to be displayed in the tree editor """
     def get_label(self):
         return get_bundle_name(self.adaptee.bundle)
 
@@ -158,6 +160,7 @@ register_factory(KPICalculatorAdapter, BaseKPICalculatorModel, ITreeNode)
 
 tree_editor = TreeEditor(
     nodes=[
+        # Root node "Workflow"
         TreeNode(node_for=[WorkflowModelView],
                  auto_open=True,
                  children='',
@@ -165,6 +168,7 @@ tree_editor = TreeEditor(
                  view=no_view,
                  menu=no_menu,
                  ),
+        # Folder node "MCO" containing the MCO
         TreeNode(node_for=[WorkflowModelView],
                  auto_open=True,
                  children='mco_representation',
@@ -172,6 +176,7 @@ tree_editor = TreeEditor(
                  view=no_view,
                  menu=Menu(new_mco_action),
                  ),
+        # Node representing the MCO
         TreeNode(node_for=[MCOModelView],
                  auto_open=True,
                  children='',
@@ -179,6 +184,7 @@ tree_editor = TreeEditor(
                  view=View(UItem('model', style="custom"), kind="subpanel"),
                  menu=Menu(delete_mco_action),
                  ),
+        # Folder node "Parameters" containing the MCO parameters
         TreeNode(node_for=[MCOModelView],
                  auto_open=True,
                  children='mco_parameters_representation',
@@ -186,6 +192,7 @@ tree_editor = TreeEditor(
                  view=no_view,
                  menu=Menu(new_parameter_action),
                  ),
+        # Folder node "Data Sources" containing the DataSources
         TreeNode(node_for=[WorkflowModelView],
                  auto_open=True,
                  children='data_sources_representation',
@@ -193,6 +200,7 @@ tree_editor = TreeEditor(
                  view=no_view,
                  menu=Menu(new_data_source_action),
                  ),
+        # Folder node "KPI Calculators" containing the KPI Calculators
         TreeNode(node_for=[WorkflowModelView],
                  auto_open=True,
                  children='kpi_calculators_representation',
@@ -205,8 +213,7 @@ tree_editor = TreeEditor(
 
 
 class WorkflowSettings(TraitsDockPane):
-    """ Side pane which contains the list of available MCOs/Data sources/ KPI
-    calculators bundles and the tree editor displaying the Workflow """
+    """ Side pane which contains the tree editor displaying the Workflow """
 
     id = 'force_wfmanager.workflow_settings'
     name = 'Workflow Settings'

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -5,7 +5,7 @@ from traitsui.api import (
 from traits.api import Instance, List, provides, register_factory
 
 from force_bdss.api import (
-    BaseMCOModel, BaseMCOBundle,
+    BaseMCOBundle,
     BaseDataSourceModel, BaseDataSourceBundle,
     BaseKPICalculatorModel, BaseKPICalculatorBundle,
     BaseMCOParameter, BaseMCOParameterFactory)

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -54,11 +54,17 @@ class WorkflowHandler(Handler):
     def delete_mco_handler(self, editor, object):
         editor.object.workflow.model.mco = None
 
+    def delete_mco_parameter_handler(self, editor, object):
+        workflow = editor.object.workflow.model
+        workflow.mco.parameters.remove(object)
+
     def delete_data_source_handler(self, editor, object):
-        editor.object.workflow.model.data_sources.remove(object)
+        workflow = editor.object.workflow.model
+        workflow.data_sources.remove(object)
 
     def delete_kpi_calculator_handler(self, editor, object):
-        editor.object.workflow.model.kpi_calculators.remove(object)
+        workflow = editor.object.workflow.model
+        workflow.kpi_calculators.remove(object)
 
 
 new_mco_action = Action(
@@ -80,6 +86,11 @@ new_kpi_calculator_action = Action(
 delete_mco_action = Action(
     name='Delete',
     action='handler.delete_mco_handler(editor, object)'
+)
+
+delete_mco_parameter_action = Action(
+    name='Delete',
+    action='handler.delete_mco_parameter_handler(editor, object)'
 )
 
 delete_data_source_action = Action(
@@ -106,7 +117,7 @@ class MCOParameterAdapter(ITreeNodeAdapter):
         return view
 
     def get_menu(self):
-        return Menu()
+        return Menu(delete_mco_parameter_action)
 
 
 @provides(ITreeNode)

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -6,8 +6,7 @@ from traits.api import Instance, List, provides, register_factory
 
 from force_bdss.api import (
     BaseMCOModel, BaseDataSourceModel, BaseKPICalculatorModel,
-    BaseMultiCriteriaOptimizerBundle, BaseDataSourceBundle,
-    BaseKPICalculatorBundle)
+    BaseMCOBundle, BaseDataSourceBundle, BaseKPICalculatorBundle)
 
 from .view_utils import get_bundle_name
 from .new_entity_modal import NewEntityModal
@@ -42,7 +41,7 @@ class WorkflowHandler(Handler):
         modal.configure_traits()
 
     def delete_mco_handler(self, editor, object):
-        editor.object.workflow.model.multi_criteria_optimizer = None
+        editor.object.workflow.model.mco = None
 
     def delete_data_source_handler(self, editor, object):
         editor.object.workflow.model.data_sources.remove(object)
@@ -172,7 +171,7 @@ class WorkflowSettings(TraitsDockPane):
     name = 'Workflow Settings'
 
     #: Available MCO bundles
-    available_mcos = List(BaseMultiCriteriaOptimizerBundle)
+    available_mcos = List(BaseMCOBundle)
 
     #: Available data source bundles
     available_data_sources = List(BaseDataSourceBundle)
@@ -181,7 +180,7 @@ class WorkflowSettings(TraitsDockPane):
     available_kpi_calculators = List(BaseKPICalculatorBundle)
 
     #: Selected MCO bundle in the list of MCOs
-    selected_mco = Instance(BaseMultiCriteriaOptimizerBundle)
+    selected_mco = Instance(BaseMCOBundle)
 
     workflow = Instance(WorkflowModelView)
 

--- a/force_wfmanager/wfmanager_plugin.py
+++ b/force_wfmanager/wfmanager_plugin.py
@@ -16,8 +16,7 @@ class WfManagerPlugin(Plugin):
     tasks = List(contributes_to=TASKS)
 
     mco_bundles = ExtensionPoint(
-        List(Instance('force_bdss.mco.i_multi_criteria_optimizer_bundle.'
-                      'IMultiCriteriaOptimizerBundle')),
+        List(Instance('force_bdss.mco.i_mco_bundle.IMCOBundle')),
         id=ExtensionPointID.MCO_BUNDLES,
         desc="""
         Available MCOs for the Workflow Manager

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -24,9 +24,9 @@ class WfManagerTask(Task):
         """ Creates the dock panes which contains the MCO, datasources and
         Constraints management """
         workflow_settings = WorkflowSettings(
-            available_mcos=self.mco_bundles,
-            available_data_sources=self.data_source_bundles,
-            available_kpi_calculators=self.kpi_calculator_bundles)
+            available_mco_factories=self.mco_bundles,
+            available_data_source_factories=self.data_source_bundles,
+            available_kpi_calculator_factories=self.kpi_calculator_bundles)
         return [workflow_settings]
 
     def _default_layout_default(self):

--- a/test/test_new_entity_modal.py
+++ b/test/test_new_entity_modal.py
@@ -64,13 +64,13 @@ class NewEntityModalTest(unittest.TestCase):
         )
         return modal, ModalInfoDummy(object=modal)
 
-    def test_add_multi_criteria_optimizer(self):
+    def test_add_mco(self):
         modal, modal_info = self._get_new_mco_dialog()
 
         # Simulate pressing add mco button (should do nothing, because no mco
         # is selected)
         self.handler.object_add_button_changed(modal_info)
-        self.assertIsNone(self.workflow.model.multi_criteria_optimizer)
+        self.assertIsNone(self.workflow.model.mco)
 
         # Simulate selecting an mco bundle in the list
         modal, modal_info = self._get_new_mco_dialog()
@@ -78,10 +78,8 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate pressing add mco button
         self.handler.object_add_button_changed(modal_info)
-        self.assertIsInstance(
-            self.workflow.model.multi_criteria_optimizer,
-            BaseMCOModel)
-        old_mco = self.workflow.model.multi_criteria_optimizer
+        self.assertIsInstance(self.workflow.model.mco, BaseMCOModel)
+        old_mco = self.workflow.model.mco
 
         # Simulate selecting an mco bundle in the list
         modal, modal_info = self._get_new_mco_dialog()
@@ -89,9 +87,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate pressing add mco button again to create a new mco model
         self.handler.object_add_button_changed(modal_info)
-        self.assertNotEqual(
-            self.workflow.model.multi_criteria_optimizer,
-            old_mco)
+        self.assertNotEqual(self.workflow.model.mco, old_mco)
 
         self.assertEqual(len(self.workflow.mco_representation), 1)
 

--- a/test/test_new_entity_modal.py
+++ b/test/test_new_entity_modal.py
@@ -46,21 +46,21 @@ class NewEntityModalTest(unittest.TestCase):
     def _get_new_mco_dialog(self):
         modal = NewEntityModal(
             workflow=self.workflow,
-            available_bundles=self.available_mcos
+            available_factories=self.available_mcos
         )
         return modal, ModalInfoDummy(object=modal)
 
     def _get_new_data_source_dialog(self):
         modal = NewEntityModal(
             workflow=self.workflow,
-            available_bundles=self.available_data_sources
+            available_factories=self.available_data_sources
         )
         return modal, ModalInfoDummy(object=modal)
 
     def _get_new_kpi_calculator_dialog(self):
         modal = NewEntityModal(
             workflow=self.workflow,
-            available_bundles=self.available_kpi_calculators
+            available_factories=self.available_kpi_calculators
         )
         return modal, ModalInfoDummy(object=modal)
 
@@ -74,7 +74,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate selecting an mco bundle in the list
         modal, modal_info = self._get_new_mco_dialog()
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing add mco button
         self.handler.object_add_button_changed(modal_info)
@@ -83,7 +83,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate selecting an mco bundle in the list
         modal, modal_info = self._get_new_mco_dialog()
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing add mco button again to create a new mco model
         self.handler.object_add_button_changed(modal_info)
@@ -100,7 +100,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate selecting a data_source bundle in the list
         modal, modal_info = self._get_new_data_source_dialog()
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing add data_source button
         self.handler.object_add_button_changed(modal_info)
@@ -112,7 +112,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate selecting a data_source bundle in the list
         modal, modal_info = self._get_new_data_source_dialog()
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing add data_source button again
         self.handler.object_add_button_changed(modal_info)
@@ -134,7 +134,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate selecting a kpi_calculator bundle in the list
         modal, modal_info = self._get_new_kpi_calculator_dialog()
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing add kpi_calculator button
         self.handler.object_add_button_changed(modal_info)
@@ -146,7 +146,7 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate selecting a kpi_calculator bundle in the list
         modal, modal_info = self._get_new_kpi_calculator_dialog()
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing add kpi_calculator button again
         self.handler.object_add_button_changed(modal_info)
@@ -163,7 +163,7 @@ class NewEntityModalTest(unittest.TestCase):
         modal, modal_info = self._get_new_mco_dialog()
 
         # Simulate selecting a kpi_calculator bundle in the list
-        modal.selected_bundle = modal.available_bundles[0]
+        modal.selected_factory = modal.available_factories[0]
 
         # Simulate pressing cancel button
         self.handler.object_cancel_button_changed(modal_info)

--- a/test/test_workflow_settings.py
+++ b/test/test_workflow_settings.py
@@ -29,9 +29,9 @@ class WorkflowSettingsEditor(HasTraits):
 def get_workflow_settings():
     plugin = mock.Mock(spec=Plugin)
     return WorkflowSettings(
-        available_mcos=[DummyDakotaBundle(plugin)],
-        available_data_sources=[CSVExtractorBundle(plugin)],
-        available_kpi_calculators=[KPIAdderBundle(plugin)]
+        available_mco_factories=[DummyDakotaBundle(plugin)],
+        available_data_source_factories=[CSVExtractorBundle(plugin)],
+        available_kpi_calculator_factories=[KPIAdderBundle(plugin)]
     )
 
 

--- a/test/test_workflow_settings.py
+++ b/test/test_workflow_settings.py
@@ -35,7 +35,7 @@ def get_workflow_settings():
 def get_workflow_model_view():
     return WorkflowModelView(
         model=Workflow(
-            multi_criteria_optimizer=mock.Mock(spec=BaseMCOModel),
+            mco=mock.Mock(spec=BaseMCOModel),
             data_sources=[mock.Mock(spec=BaseDataSourceModel),
                           mock.Mock(spec=BaseDataSourceModel)],
             kpi_calculators=[mock.Mock(spec=BaseKPICalculatorModel),
@@ -60,7 +60,7 @@ class TestWorkflowSettings(unittest.TestCase):
         self.workflow = self.settings.workflow.model
 
     def test_ui_initialization(self):
-        self.assertIsNone(self.workflow.multi_criteria_optimizer)
+        self.assertIsNone(self.workflow.mco)
         self.assertEqual(len(self.workflow.data_sources), 0)
         self.assertEqual(len(self.workflow.kpi_calculators), 0)
 
@@ -82,14 +82,14 @@ class TestTreeEditorHandler(unittest.TestCase):
 
     def test_delete_mco(self):
         self.assertIsNotNone(
-            self.workflow.model.multi_criteria_optimizer)
+            self.workflow.model.mco)
 
         self.handler.delete_mco_handler(
             self.workflow_settings_editor,
-            self.workflow.model.multi_criteria_optimizer)
+            self.workflow.model.mco)
 
         self.assertIsNone(
-            self.workflow.model.multi_criteria_optimizer)
+            self.workflow.model.mco)
 
     def test_delete_data_source(self):
         first_data_source = self.workflow.model.data_sources[0]


### PR DESCRIPTION
Adds support for MCO parameters in the UI. MCO parameters are added under the MCO in the model.
Currently, the parameters are not specific to the MCO, but it's likely they will become.
