### PR TITLE
Remove trailing attribute for the workflow settings

### DIFF
--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -235,9 +235,6 @@ class WorkflowSettings(TraitsDockPane):
     available_kpi_calculator_factories = List(Instance(
         BaseKPICalculatorBundle))
 
-    #: Selected MCO bundle in the list of MCOs
-    selected_mco = Instance(BaseMCOBundle)
-
     workflow = Instance(WorkflowModelView)
 
     workflow_model = Instance(Workflow)


### PR DESCRIPTION
The `selected_mco` attribute is not used anymore, it was an attribute representing the currently selected mco in the list of mco bundles. This list of mco bundles is now an attribute of the modal dialog, not the workflow settings class.