### PR TITLE
Rename Workflow variables

### DIFF
--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -25,7 +25,7 @@ class ModalHandler(Handler):
     def object_add_button_changed(self, info):
         """ Action triggered when clicking on "Add" button in the modal """
         if info.object.current_model is not None:
-            info.object.workflow.add_entity(info.object.current_model)
+            info.object.workflow_mv.add_entity(info.object.current_model)
         info.ui.dispose(True)
 
     def object_cancel_button_changed(self, info):
@@ -36,7 +36,7 @@ class ModalHandler(Handler):
 class NewEntityModal(HasStrictTraits):
     """ Dialog which allows the user to add a new MCO/Data Source/KPI
     calculator to the workflow """
-    workflow = Instance(WorkflowModelView)
+    workflow_mv = Instance(WorkflowModelView)
 
     #: Available factories, this class is generic and can contain any factory
     #: which implement the create_model method

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -29,14 +29,14 @@ class WorkflowHandler(Handler):
     def new_mco_handler(self, editor, object):
         """ Opens a dialog for creating a MCO """
         modal = NewEntityModal(
-            workflow=editor.object.workflow,
+            workflow_mv=editor.object._workflow_mv,
             available_factories=editor.object.available_mco_factories)
         modal.configure_traits()
 
     def new_parameter_handler(self, editor, object):
         """ Opens a dialog for creating a parameter """
         modal = NewEntityModal(
-            workflow=editor.object.workflow,
+            workflow_mv=editor.object._workflow_mv,
             available_factories=editor.object.available_mco_parameter_factories
         )
         modal.configure_traits()
@@ -44,7 +44,7 @@ class WorkflowHandler(Handler):
     def new_data_source_handler(self, editor, object):
         """ Opens a dialog for creating a Data Source """
         modal = NewEntityModal(
-            workflow=editor.object.workflow,
+            workflow_mv=editor.object._workflow_mv,
             available_factories=editor.object.available_data_source_factories)
         modal.configure_traits()
 
@@ -52,28 +52,28 @@ class WorkflowHandler(Handler):
         """ Opens a dialog for creating a KPI Calculator """
         obj = editor.object
         modal = NewEntityModal(
-            workflow=obj.workflow,
+            workflow_mv=obj._workflow_mv,
             available_factories=obj.available_kpi_calculator_factories)
         modal.configure_traits()
 
     def delete_mco_handler(self, editor, object):
         """ Delete the MCO from the workflow """
-        editor.object.workflow_model.mco = None
+        editor.object.workflow_m.mco = None
 
     def delete_mco_parameter_handler(self, editor, object):
         """ Delete one parameter from the MCO """
-        workflow = editor.object.workflow_model
-        workflow.mco.parameters.remove(object)
+        workflow_m = editor.object.workflow_m
+        workflow_m.mco.parameters.remove(object)
 
     def delete_data_source_handler(self, editor, object):
         """ Delete a DataSource from the workflow """
-        workflow = editor.object.workflow_model
-        workflow.data_sources.remove(object)
+        workflow_m = editor.object.workflow_m
+        workflow_m.data_sources.remove(object)
 
     def delete_kpi_calculator_handler(self, editor, object):
         """ Delete a KPI Calculator from the workflow """
-        workflow = editor.object.workflow_model
-        workflow.kpi_calculators.remove(object)
+        workflow_m = editor.object.workflow_m
+        workflow_m.kpi_calculators.remove(object)
 
 
 new_mco_action = Action(
@@ -228,7 +228,7 @@ class WorkflowSettings(TraitsDockPane):
     #: Available parameters factories
     available_mco_parameter_factories = Property(
         List(Instance(BaseMCOParameterFactory)),
-        depends_on='workflow_model.mco')
+        depends_on='workflow_m.mco')
 
     #: Available data source bundles
     available_data_source_factories = List(Instance(BaseDataSourceBundle))
@@ -237,12 +237,14 @@ class WorkflowSettings(TraitsDockPane):
     available_kpi_calculator_factories = List(Instance(
         BaseKPICalculatorBundle))
 
-    workflow = Instance(WorkflowModelView)
+    #: The workflow model view
+    _workflow_mv = Instance(WorkflowModelView)
 
-    workflow_model = Instance(Workflow)
+    #: The workflow model
+    workflow_m = Instance(Workflow)
 
     traits_view = View(
-        UItem(name='workflow',
+        UItem(name='_workflow_mv',
               editor=tree_editor,
               show_label=False),
         width=800,
@@ -250,15 +252,15 @@ class WorkflowSettings(TraitsDockPane):
         resizable=True,
         handler=WorkflowHandler())
 
-    def _workflow_default(self):
+    def __workflow_mv_default(self):
         return WorkflowModelView(
-            model=self.workflow_model
+            model=self.workflow_m
         )
 
-    @on_trait_change('workflow_model')
+    @on_trait_change('workflow_m')
     def update_model_view(self):
-        self.workflow.model = self.workflow_model
+        self._workflow_mv.model = self.workflow_m
 
     def _get_available_mco_parameter_factories(self):
-        mco_bundle = self.workflow_model.mco.bundle
+        mco_bundle = self.workflow_m.mco.bundle
         return mco_bundle.parameter_factories()

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -18,7 +18,7 @@ class WfManagerTask(Task):
     name = 'Workflow Manager'
 
     #: Workflow model
-    workflow = Instance(Workflow)
+    workflow_m = Instance(Workflow)
 
     #: WorkflowSettings pane, it displays the workflow in a tree editor and
     #: allows to edit it
@@ -60,7 +60,7 @@ class WfManagerTask(Task):
         if result is OK:
             writer = WorkflowWriter()
             with open(dialog.path, 'wr') as output:
-                writer.write(self.workflow, output)
+                writer.write(self.workflow_m, output)
 
     def load_workflow(self):
         """ Shows a dialog to load a workflow file """
@@ -71,7 +71,7 @@ class WfManagerTask(Task):
             reader = WorkflowReader(self.bundle_registry)
             try:
                 with open(dialog.path, 'r') as fobj:
-                    self.workflow = reader.read(fobj)
+                    self.workflow_m = reader.read(fobj)
             except InvalidFileException as e:
                 error(
                     None,
@@ -86,7 +86,7 @@ class WfManagerTask(Task):
             left=PaneItem('force_wfmanager.workflow_settings')
         )
 
-    def _workflow_default(self):
+    def _workflow_m_default(self):
         return Workflow()
 
     def _workflow_settings_default(self):
@@ -95,8 +95,8 @@ class WfManagerTask(Task):
             available_mco_factories=registry.mco_bundles,
             available_data_source_factories=registry.data_source_bundles,
             available_kpi_calculator_factories=registry.kpi_calculator_bundles,
-            workflow_model=self.workflow)
+            workflow_m=self.workflow_m)
 
-    @on_trait_change('workflow')
+    @on_trait_change('workflow_m')
     def update_workflow_settings(self):
-        self.workflow_settings.workflow_model = self.workflow
+        self.workflow_settings.workflow_m = self.workflow_m

--- a/test/test_new_entity_modal.py
+++ b/test/test_new_entity_modal.py
@@ -46,7 +46,7 @@ class NewEntityModalTest(unittest.TestCase):
         self.available_data_sources = [CSVExtractorBundle(plugin)]
         self.available_kpi_calculators = [KPIAdderBundle(plugin)]
 
-        self.workflow = WorkflowModelView(
+        self.workflow_mv = WorkflowModelView(
             model=Workflow()
         )
 
@@ -54,21 +54,21 @@ class NewEntityModalTest(unittest.TestCase):
 
     def _get_new_mco_dialog(self):
         modal = NewEntityModal(
-            workflow=self.workflow,
+            workflow_mv=self.workflow_mv,
             available_factories=self.available_mcos
         )
         return modal, ModalInfoDummy(object=modal)
 
     def _get_new_data_source_dialog(self):
         modal = NewEntityModal(
-            workflow=self.workflow,
+            workflow_mv=self.workflow_mv,
             available_factories=self.available_data_sources
         )
         return modal, ModalInfoDummy(object=modal)
 
     def _get_new_kpi_calculator_dialog(self):
         modal = NewEntityModal(
-            workflow=self.workflow,
+            workflow_mv=self.workflow_mv,
             available_factories=self.available_kpi_calculators
         )
         return modal, ModalInfoDummy(object=modal)
@@ -79,7 +79,7 @@ class NewEntityModalTest(unittest.TestCase):
         # Simulate pressing add mco button (should do nothing, because no mco
         # is selected)
         self.handler.object_add_button_changed(modal_info)
-        self.assertIsNone(self.workflow.model.mco)
+        self.assertIsNone(self.workflow_mv.model.mco)
 
         # Simulate selecting an mco bundle in the list
         modal, modal_info = self._get_new_mco_dialog()
@@ -87,8 +87,8 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate pressing add mco button
         self.handler.object_add_button_changed(modal_info)
-        self.assertIsInstance(self.workflow.model.mco, BaseMCOModel)
-        old_mco = self.workflow.model.mco
+        self.assertIsInstance(self.workflow_mv.model.mco, BaseMCOModel)
+        old_mco = self.workflow_mv.model.mco
 
         # Simulate selecting an mco bundle in the list
         modal, modal_info = self._get_new_mco_dialog()
@@ -96,16 +96,16 @@ class NewEntityModalTest(unittest.TestCase):
 
         # Simulate pressing add mco button again to create a new mco model
         self.handler.object_add_button_changed(modal_info)
-        self.assertNotEqual(self.workflow.model.mco, old_mco)
+        self.assertNotEqual(self.workflow_mv.model.mco, old_mco)
 
-        self.assertEqual(len(self.workflow.mco_representation), 1)
+        self.assertEqual(len(self.workflow_mv.mco_representation), 1)
 
     def test_add_data_source(self):
         modal, modal_info = self._get_new_data_source_dialog()
 
         # Simulate pressing add data_source button (should do nothing)
         self.handler.object_add_button_changed(modal_info)
-        self.assertEqual(len(self.workflow.model.data_sources), 0)
+        self.assertEqual(len(self.workflow_mv.model.data_sources), 0)
 
         # Simulate selecting a data_source bundle in the list
         modal, modal_info = self._get_new_data_source_dialog()
@@ -114,10 +114,10 @@ class NewEntityModalTest(unittest.TestCase):
         # Simulate pressing add data_source button
         self.handler.object_add_button_changed(modal_info)
         self.assertIsInstance(
-            self.workflow.model.data_sources[0],
+            self.workflow_mv.model.data_sources[0],
             BaseDataSourceModel)
 
-        self.assertEqual(len(self.workflow.data_sources_representation), 1)
+        self.assertEqual(len(self.workflow_mv.data_sources_representation), 1)
 
         # Simulate selecting a data_source bundle in the list
         modal, modal_info = self._get_new_data_source_dialog()
@@ -126,20 +126,20 @@ class NewEntityModalTest(unittest.TestCase):
         # Simulate pressing add data_source button again
         self.handler.object_add_button_changed(modal_info)
         self.assertIsInstance(
-            self.workflow.model.data_sources[1],
+            self.workflow_mv.model.data_sources[1],
             BaseDataSourceModel)
         self.assertNotEqual(
-            self.workflow.model.data_sources[0],
-            self.workflow.model.data_sources[1])
+            self.workflow_mv.model.data_sources[0],
+            self.workflow_mv.model.data_sources[1])
 
-        self.assertEqual(len(self.workflow.data_sources_representation), 2)
+        self.assertEqual(len(self.workflow_mv.data_sources_representation), 2)
 
     def test_add_kpi_calculator(self):
         modal, modal_info = self._get_new_kpi_calculator_dialog()
 
         # Simulate pressing add kpi_calculator button (should do nothing)
         self.handler.object_add_button_changed(modal_info)
-        self.assertEqual(len(self.workflow.model.kpi_calculators), 0)
+        self.assertEqual(len(self.workflow_mv.model.kpi_calculators), 0)
 
         # Simulate selecting a kpi_calculator bundle in the list
         modal, modal_info = self._get_new_kpi_calculator_dialog()
@@ -148,10 +148,11 @@ class NewEntityModalTest(unittest.TestCase):
         # Simulate pressing add kpi_calculator button
         self.handler.object_add_button_changed(modal_info)
         self.assertIsInstance(
-            self.workflow.model.kpi_calculators[0],
+            self.workflow_mv.model.kpi_calculators[0],
             BaseKPICalculatorModel)
 
-        self.assertEqual(len(self.workflow.kpi_calculators_representation), 1)
+        self.assertEqual(
+            len(self.workflow_mv.kpi_calculators_representation), 1)
 
         # Simulate selecting a kpi_calculator bundle in the list
         modal, modal_info = self._get_new_kpi_calculator_dialog()
@@ -160,13 +161,14 @@ class NewEntityModalTest(unittest.TestCase):
         # Simulate pressing add kpi_calculator button again
         self.handler.object_add_button_changed(modal_info)
         self.assertIsInstance(
-            self.workflow.model.kpi_calculators[1],
+            self.workflow_mv.model.kpi_calculators[1],
             BaseKPICalculatorModel)
         self.assertNotEqual(
-            self.workflow.model.kpi_calculators[0],
-            self.workflow.model.kpi_calculators[1])
+            self.workflow_mv.model.kpi_calculators[0],
+            self.workflow_mv.model.kpi_calculators[1])
 
-        self.assertEqual(len(self.workflow.kpi_calculators_representation), 2)
+        self.assertEqual(
+            len(self.workflow_mv.kpi_calculators_representation), 2)
 
     def test_cancel_button(self):
         modal, modal_info = self._get_new_mco_dialog()

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -96,12 +96,12 @@ class TestWFManagerTask(unittest.TestCase):
             mock_file_open.side_effect = mock_open
             mock_reader.side_effect = mock_file_reader
 
-            old_workflow = self.wfmanager_task.workflow
+            old_workflow = self.wfmanager_task.workflow_m
 
             self.wfmanager_task.load_workflow()
 
             mock_reader.assert_called()
-            self.assertNotEqual(old_workflow, self.wfmanager_task.workflow)
+            self.assertNotEqual(old_workflow, self.wfmanager_task.workflow_m)
 
     def test_load_failure(self):
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
@@ -113,7 +113,7 @@ class TestWFManagerTask(unittest.TestCase):
             mock_error.side_effect = mock_show_error
             mock_reader.side_effect = mock_file_reader_failure
 
-            old_workflow = self.wfmanager_task.workflow
+            old_workflow = self.wfmanager_task.workflow_m
 
             self.wfmanager_task.load_workflow()
 
@@ -123,4 +123,4 @@ class TestWFManagerTask(unittest.TestCase):
                 'Cannot read the requested file:\n\nOUPS',
                 'Error when reading file'
             )
-            self.assertEqual(old_workflow, self.wfmanager_task.workflow)
+            self.assertEqual(old_workflow, self.wfmanager_task.workflow_m)

--- a/test/test_workflow_settings.py
+++ b/test/test_workflow_settings.py
@@ -32,7 +32,7 @@ def get_workflow_settings():
         available_mco_factories=[DummyDakotaBundle(plugin)],
         available_data_source_factories=[CSVExtractorBundle(plugin)],
         available_kpi_calculator_factories=[KPIAdderBundle(plugin)],
-        workflow_model=Workflow(),
+        workflow_m=Workflow(),
     )
 
 
@@ -51,8 +51,8 @@ def get_workflow_model_view():
 def get_workflow_settings_editor(workflow_model_view):
     return WorkflowSettingsEditor(
         object=WorkflowSettings(
-            workflow=workflow_model_view,
-            workflow_model=workflow_model_view.model
+            _workflow_mv=workflow_model_view,
+            workflow_m=workflow_model_view.model
         )
     )
 
@@ -62,18 +62,17 @@ class TestWorkflowSettings(unittest.TestCase):
         self.workflow_settings = get_workflow_settings()
 
         self.settings = self.workflow_settings
-        self.workflow = self.settings.workflow.model
 
     def test_ui_initialization(self):
-        self.assertIsNone(self.workflow.mco)
-        self.assertEqual(len(self.workflow.data_sources), 0)
-        self.assertEqual(len(self.workflow.kpi_calculators), 0)
+        self.assertIsNone(self.settings.workflow_m.mco)
+        self.assertEqual(len(self.settings.workflow_m.data_sources), 0)
+        self.assertEqual(len(self.settings.workflow_m.kpi_calculators), 0)
 
-        self.assertEqual(len(self.settings.workflow.mco_representation), 0)
+        self.assertEqual(len(self.settings._workflow_mv.mco_representation), 0)
         self.assertEqual(
-            len(self.settings.workflow.data_sources_representation), 0)
+            len(self.settings._workflow_mv.data_sources_representation), 0)
         self.assertEqual(
-            len(self.settings.workflow.kpi_calculators_representation), 0)
+            len(self.settings._workflow_mv.kpi_calculators_representation), 0)
 
 
 class TestTreeEditorHandler(unittest.TestCase):


### PR DESCRIPTION
Rename Workflow variables so that it is easier to understand which is the workflow model view object and the workflow model object (`workflow_mv` and `workflow_m`)

I also made the workflow model view private inside the `WorkflowSettings` class