### PR TITLE
Add result table

### DIFF
--- a/force_wfmanager/central_pane/analysis.py
+++ b/force_wfmanager/central_pane/analysis.py
@@ -1,8 +1,10 @@
 from pyface.tasks.api import TraitsTaskPane
 
-from traits.api import List, Str, Tuple, Int
+from traits.api import List, Str, Tuple, Int, Instance
 
-from traitsui.api import View, Tabbed, VGroup, Spring
+from traitsui.api import View, UItem, Tabbed, VGroup, Spring
+
+from .result_table import ResultTable
 
 
 class Analysis(TraitsTaskPane):
@@ -21,9 +23,13 @@ class Analysis(TraitsTaskPane):
     #: Selected step, used for highlighting in the table/plot
     selected_step_index = Int(None)
 
+    #: The table in which we display the computation results received from the
+    #: bdss
+    result_table = Instance(ResultTable)
+
     view = View(Tabbed(
         VGroup(
-            Spring(),
+            UItem(name='result_table', style='custom'),
             label='Result Table'
         ),
         VGroup(
@@ -31,3 +37,9 @@ class Analysis(TraitsTaskPane):
             label='Pareto Front'
         )
     ))
+
+    def _result_table_default(self):
+        return ResultTable(
+            value_names=self.value_names,
+            evaluation_steps=self.evaluation_steps
+        )

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -1,0 +1,35 @@
+from traits.api import HasStrictTraits, List, Str, Tuple, Property
+
+from traitsui.api import View, UItem, TableEditor
+from traitsui.table_column import ListColumn
+
+
+table_editor = TableEditor(
+    sortable=False,
+    configurable=False,
+    auto_size=False,
+    columns_name='columns'
+)
+
+
+class ResultTable(HasStrictTraits):
+    #: List of parameter names
+    value_names = List(Str)
+
+    #: List of evaluation steps
+    evaluation_steps = List(Tuple())
+
+    #: Columns of the table_editor
+    columns = Property(
+        List(ListColumn),
+        depends_on='value_names'
+    )
+
+    view = View(
+        UItem(name='evaluation_steps', editor=table_editor)
+    )
+
+    def _get_columns(self):
+        return [ListColumn(label=name, index=index)
+                for index, name
+                in enumerate(self.value_names)]

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -12,6 +12,15 @@ class AnalysisTest(unittest.TestCase):
         self.assertEqual(len(self.analysis.evaluation_steps), 0)
         self.assertIsNone(self.analysis.selected_step_index)
 
+        self.assertEqual(
+            self.analysis.result_table.evaluation_steps,
+            self.analysis.evaluation_steps
+        )
+        self.assertEqual(
+            self.analysis.result_table.value_names,
+            self.analysis.value_names
+        )
+
     def test_evaluation_steps(self):
         self.analysis.evaluation_steps = [
             (2.3, 5.2, 'C0'),

--- a/test/test_result_table.py
+++ b/test/test_result_table.py
@@ -1,0 +1,23 @@
+import unittest
+
+from force_wfmanager.central_pane.result_table import ResultTable
+
+
+class ResultTableTest(unittest.TestCase):
+    def setUp(self):
+        self.result_table = ResultTable(
+            value_names=['x', 'y', 'compound'],
+            evaluation_steps=[
+                (2.1, 56, 'CO'),
+                (1.23, 51.2, 'CO2')
+            ]
+        )
+
+    def test_columns(self):
+        self.assertEqual(len(self.result_table.columns), 3)
+        self.assertEqual(self.result_table.columns[2].label, 'compound')
+
+    def test_value(self):
+        column_2 = self.result_table.columns[2]
+        row_1 = self.result_table.evaluation_steps[1]
+        self.assertEqual(column_2.get_value(row_1), 'CO2')


### PR DESCRIPTION
Adds a result table in the main UI pane. This table will display the results obtained by the evaluation. Columns will be titled over the input parameter values and KPI obtained. Rows will be the individual evaluations.