### PR TITLE
Introduce base views

### DIFF
--- a/force_wfmanager/left_side_pane/view_utils.py
+++ b/force_wfmanager/left_side_pane/view_utils.py
@@ -21,4 +21,11 @@ base_mco_parameter_view = View(
 base_data_source_view = View(
     Item(name="input_slot_maps"),
     Item(name="output_slot_names"),
+    kind="subpanel",
+)
+
+base_kpi_calculator_view = View(
+    Item(name="input_slot_maps"),
+    Item(name="output_slot_names"),
+    kind="subpanel",
 )

--- a/force_wfmanager/left_side_pane/view_utils.py
+++ b/force_wfmanager/left_side_pane/view_utils.py
@@ -1,3 +1,6 @@
+from traitsui.api import View, Item
+
+
 def get_factory_name(factory):
     """ Returns a factory name, given the factory. This ensure that something
     will be displayed (id or name of the factory) even if no name has been
@@ -7,3 +10,10 @@ def get_factory_name(factory):
         return name
     else:
         return factory.id
+
+
+base_mco_parameter_view = View(
+    Item(name="name"),
+    Item(name="type"),
+    kind="subpanel",
+)

--- a/force_wfmanager/left_side_pane/view_utils.py
+++ b/force_wfmanager/left_side_pane/view_utils.py
@@ -17,3 +17,8 @@ base_mco_parameter_view = View(
     Item(name="type"),
     kind="subpanel",
 )
+
+base_data_source_view = View(
+    Item(name="input_slot_maps"),
+    Item(name="output_slot_names"),
+)

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -14,7 +14,8 @@ from force_bdss.api import (
 from force_bdss.core.workflow import Workflow
 
 from .view_utils import (
-    get_factory_name, base_mco_parameter_view, base_data_source_view)
+    get_factory_name,
+    base_mco_parameter_view, base_data_source_view, base_kpi_calculator_view)
 from .new_entity_modal import NewEntityModal
 from .workflow_model_view import WorkflowModelView
 from .mco_model_view import MCOModelView
@@ -133,10 +134,7 @@ class MCOParameterAdapter(ITreeNodeAdapter):
         return base_mco_parameter_view
 
     def get_menu(self):
-        return Menu(
-            edit_entity_action,
-            delete_mco_parameter_action,
-        )
+        return Menu(edit_entity_action, delete_mco_parameter_action)
 
 
 @provides(ITreeNode)
@@ -149,10 +147,7 @@ class DataSourceAdapter(ITreeNodeAdapter):
         return base_data_source_view
 
     def get_menu(self):
-        return Menu(
-            edit_entity_action,
-            delete_data_source_action
-        )
+        return Menu(edit_entity_action, delete_data_source_action)
 
 
 @provides(ITreeNode)
@@ -162,12 +157,10 @@ class KPICalculatorAdapter(ITreeNodeAdapter):
         return get_factory_name(self.adaptee.factory)
 
     def get_view(self):
-        view = self.adaptee.trait_view()
-        view.kind = "subpanel"
-        return view
+        return base_kpi_calculator_view
 
     def get_menu(self):
-        return Menu(delete_kpi_calculator_action)
+        return Menu(edit_entity_action, delete_kpi_calculator_action)
 
 
 register_factory(MCOParameterAdapter, BaseMCOParameter, ITreeNode)

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -13,7 +13,7 @@ from force_bdss.api import (
     BaseMCOParameter, BaseMCOParameterFactory)
 from force_bdss.core.workflow import Workflow
 
-from .view_utils import get_factory_name
+from .view_utils import get_factory_name, base_mco_parameter_view
 from .new_entity_modal import NewEntityModal
 from .workflow_model_view import WorkflowModelView
 from .mco_model_view import MCOModelView
@@ -31,7 +31,7 @@ class WorkflowHandler(Handler):
         modal = NewEntityModal(
             workflow_mv=editor.object._workflow_mv,
             available_factories=editor.object.available_mco_factories)
-        modal.configure_traits()
+        modal.edit_traits()
 
     def new_parameter_handler(self, editor, object):
         """ Opens a dialog for creating a parameter """
@@ -39,14 +39,14 @@ class WorkflowHandler(Handler):
             workflow_mv=editor.object._workflow_mv,
             available_factories=editor.object.available_mco_parameter_factories
         )
-        modal.configure_traits()
+        modal.edit_traits()
 
     def new_data_source_handler(self, editor, object):
         """ Opens a dialog for creating a Data Source """
         modal = NewEntityModal(
             workflow_mv=editor.object._workflow_mv,
             available_factories=editor.object.available_data_source_factories)
-        modal.configure_traits()
+        modal.edit_traits()
 
     def new_kpi_calculator_handler(self, editor, object):
         """ Opens a dialog for creating a KPI Calculator """
@@ -54,7 +54,11 @@ class WorkflowHandler(Handler):
         modal = NewEntityModal(
             workflow_mv=obj._workflow_mv,
             available_factories=obj.available_kpi_calculator_factories)
-        modal.configure_traits()
+        modal.edit_traits()
+
+    def edit_entity_handler(self, editor, object):
+        """ Opens a dialog for configuring the workflow element """
+        object.edit_traits()
 
     def delete_mco_handler(self, editor, object):
         """ Delete the MCO from the workflow """
@@ -92,6 +96,11 @@ new_kpi_calculator_action = Action(
     name='New KPI Calculator...',
     action='handler.new_kpi_calculator_handler(editor, object)')
 
+edit_entity_action = Action(
+    name='Edit',
+    action='handler.edit_entity_handler(editor, object)'
+)
+
 delete_mco_action = Action(
     name='Delete',
     action='handler.delete_mco_handler(editor, object)'
@@ -120,12 +129,13 @@ class MCOParameterAdapter(ITreeNodeAdapter):
         return get_factory_name(self.adaptee.factory)
 
     def get_view(self):
-        view = self.adaptee.trait_view()
-        view.kind = "subpanel"
-        return view
+        return base_mco_parameter_view
 
     def get_menu(self):
-        return Menu(delete_mco_parameter_action)
+        return Menu(
+            edit_entity_action,
+            delete_mco_parameter_action,
+        )
 
 
 @provides(ITreeNode)

--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -13,7 +13,8 @@ from force_bdss.api import (
     BaseMCOParameter, BaseMCOParameterFactory)
 from force_bdss.core.workflow import Workflow
 
-from .view_utils import get_factory_name, base_mco_parameter_view
+from .view_utils import (
+    get_factory_name, base_mco_parameter_view, base_data_source_view)
 from .new_entity_modal import NewEntityModal
 from .workflow_model_view import WorkflowModelView
 from .mco_model_view import MCOModelView
@@ -145,12 +146,13 @@ class DataSourceAdapter(ITreeNodeAdapter):
         return get_factory_name(self.adaptee.factory)
 
     def get_view(self):
-        view = self.adaptee.trait_view()
-        view.kind = "subpanel"
-        return view
+        return base_data_source_view
 
     def get_menu(self):
-        return Menu(delete_data_source_action)
+        return Menu(
+            edit_entity_action,
+            delete_data_source_action
+        )
 
 
 @provides(ITreeNode)

--- a/test/test_mco_model_view.py
+++ b/test/test_mco_model_view.py
@@ -1,0 +1,26 @@
+import unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from force_bdss.api import BaseMCOModel, BaseMCOFactory
+
+from force_wfmanager.left_side_pane.mco_model_view import MCOModelView
+
+
+class MCOModelViewTest(unittest.TestCase):
+    def setUp(self):
+        mock_model = mock.Mock(spec=BaseMCOModel)
+        mock_model.parameters = ["foo", "bar"]
+        mock_model.factory = mock.Mock(spec=BaseMCOFactory)
+        mock_model.factory.name = "baz"
+
+        self.mco_mv = MCOModelView(model=mock_model)
+
+    def test_mco_parameter_representation(self):
+        self.assertEqual(
+            self.mco_mv.mco_parameters_representation, ["foo", "bar"])
+
+    def test_label(self):
+        self.assertEqual(self.mco_mv.label, "baz")

--- a/test/test_workflow_settings.py
+++ b/test/test_workflow_settings.py
@@ -25,6 +25,8 @@ from force_wfmanager.left_side_pane.workflow_model_view import \
 from force_wfmanager.left_side_pane.workflow_settings import (
     WorkflowSettings, WorkflowHandler, MCOParameterAdapter, DataSourceAdapter,
     KPICalculatorAdapter)
+from force_wfmanager.left_side_pane.view_utils import (
+    base_mco_parameter_view, base_data_source_view, base_kpi_calculator_view)
 
 
 class WorkflowSettingsEditor(HasTraits):
@@ -139,8 +141,10 @@ class TestTreeEditorHandler(unittest.TestCase):
 
         self.assertEqual(adapter.get_label(), 'Hi')
 
-        adapter.get_view()
-        model.trait_view.assert_called()
+        self.assertEqual(
+            adapter.get_view(),
+            base_mco_parameter_view
+        )
 
     def test_data_source_adapter(self):
         model = mock.Mock(spec=BaseDataSourceModel)
@@ -151,8 +155,10 @@ class TestTreeEditorHandler(unittest.TestCase):
 
         self.assertEqual(adapter.get_label(), 'Hi')
 
-        adapter.get_view()
-        model.trait_view.assert_called()
+        self.assertEqual(
+            adapter.get_view(),
+            base_data_source_view
+        )
 
     def test_kpi_calculator_adapter(self):
         model = mock.Mock(spec=BaseKPICalculatorModel)
@@ -163,5 +169,7 @@ class TestTreeEditorHandler(unittest.TestCase):
 
         self.assertEqual(adapter.get_label(), 'Hi')
 
-        adapter.get_view()
-        model.trait_view.assert_called()
+        self.assertEqual(
+            adapter.get_view(),
+            base_kpi_calculator_view
+        )

--- a/test/test_workflow_settings.py
+++ b/test/test_workflow_settings.py
@@ -8,6 +8,8 @@ from envisage.plugin import Plugin
 
 from traits.api import Instance, HasTraits
 
+from traitsui.api import Menu
+
 from force_bdss.core_plugins.dummy.dummy_dakota.dakota_factory import (
     DummyDakotaFactory)
 from force_bdss.core_plugins.dummy.csv_extractor.csv_extractor_factory import (
@@ -228,6 +230,11 @@ class TestTreeEditorHandler(unittest.TestCase):
             base_mco_parameter_view
         )
 
+        self.assertIsInstance(
+            adapter.get_menu(),
+            Menu
+        )
+
     def test_data_source_adapter(self):
         model = mock.Mock(spec=BaseDataSourceModel)
         model.factory = mock.Mock(spec=BaseDataSourceFactory)
@@ -242,6 +249,11 @@ class TestTreeEditorHandler(unittest.TestCase):
             base_data_source_view
         )
 
+        self.assertIsInstance(
+            adapter.get_menu(),
+            Menu
+        )
+
     def test_kpi_calculator_adapter(self):
         model = mock.Mock(spec=BaseKPICalculatorModel)
         model.factory = mock.Mock(spec=BaseKPICalculatorFactory)
@@ -254,4 +266,9 @@ class TestTreeEditorHandler(unittest.TestCase):
         self.assertEqual(
             adapter.get_view(),
             base_kpi_calculator_view
+        )
+
+        self.assertIsInstance(
+            adapter.get_menu(),
+            Menu
         )

--- a/test/test_workflow_settings.py
+++ b/test/test_workflow_settings.py
@@ -148,6 +148,16 @@ class TestTreeEditorHandler(unittest.TestCase):
 
             mock_modal.assert_called()
 
+    def test_edit_entity(self):
+        self.handler.edit_entity_handler(
+            self.workflow_settings_editor,
+            self.workflow.model.mco)
+
+        self.assertEqual(
+            self.workflow.model.mco.edit_traits.call_count,
+            1
+        )
+
     def test_delete_mco(self):
         self.assertIsNotNone(
             self.workflow.model.mco)


### PR DESCRIPTION
Introduce base views for each element of the Workflow (MCO parameter, Data source, KPI calculator). Those base views are displayed when clicking on the specific element in the tree. 
The user can now edit those element by right clicking on the element in the tree, and click "Edit". 