### PR TITLE
Add current_file attribute

### DIFF
--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -65,7 +65,10 @@ class WfManagerTask(Task):
             current_file = self.current_file
         else:
             dialog = FileDialog(
-                action="save as", default_filename="workflow.json")
+                action="save as",
+                default_filename="workflow.json",
+                wildcard='JSON files (*.json)|*.json|'
+            )
             result = dialog.open()
 
             if result is not OK:
@@ -87,7 +90,10 @@ class WfManagerTask(Task):
 
     def load_workflow(self):
         """ Shows a dialog to load a workflow file """
-        dialog = FileDialog(action="open")
+        dialog = FileDialog(
+            action="open",
+            wildcard='JSON files (*.json)|*.json|'
+        )
         result = dialog.open()
 
         if result is OK:

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -73,9 +73,17 @@ class WfManagerTask(Task):
 
             current_file = dialog.path
 
-        with open(current_file, 'w') as output:
-            writer.write(self.workflow_m, output)
-            self.current_file = current_file
+        try:
+            with open(current_file, 'w') as output:
+                writer.write(self.workflow_m, output)
+                self.current_file = current_file
+        except IOError as e:
+            error(
+                None,
+                'Cannot save in the requested file:\n\n{}'.format(
+                    str(e)),
+                'Error when saving workflow'
+            )
 
     def load_workflow(self):
         """ Shows a dialog to load a workflow file """

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -1,4 +1,4 @@
-from traits.api import Instance, on_trait_change, Str
+from traits.api import Instance, on_trait_change, File
 
 from pyface.tasks.api import Task, TaskLayout, PaneItem
 from pyface.tasks.action.api import SMenu, SMenuBar, TaskAction
@@ -28,7 +28,7 @@ class WfManagerTask(Task):
     factory_registry = Instance(FactoryRegistryPlugin)
 
     #: Current workflow file on which the application is writing
-    current_file = Str()
+    current_file = File()
 
     #: Menu bar on top of the GUI
     menu_bar = SMenuBar(SMenu(

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -62,7 +62,7 @@ class WfManagerTask(Task):
         # If the user already saved before or loaded a file, we overwrite this
         # one
         if len(self.current_file) != 0:
-            with open(self.current_file, 'wr') as output:
+            with open(self.current_file, 'w') as output:
                 writer.write(self.workflow_m, output)
             return
 
@@ -70,7 +70,7 @@ class WfManagerTask(Task):
         result = dialog.open()
 
         if result is OK:
-            with open(dialog.path, 'wr') as output:
+            with open(dialog.path, 'w') as output:
                 writer.write(self.workflow_m, output)
             self.current_file = dialog.path
 

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -60,19 +60,22 @@ class WfManagerTask(Task):
         writer = WorkflowWriter()
 
         # If the user already saved before or loaded a file, we overwrite this
-        # one
+        # file
         if len(self.current_file) != 0:
-            with open(self.current_file, 'w') as output:
-                writer.write(self.workflow_m, output)
-            return
+            current_file = self.current_file
+        else:
+            dialog = FileDialog(
+                action="save as", default_filename="workflow.json")
+            result = dialog.open()
 
-        dialog = FileDialog(action="save as", default_filename="workflow.json")
-        result = dialog.open()
+            if result is not OK:
+                return
 
-        if result is OK:
-            with open(dialog.path, 'w') as output:
-                writer.write(self.workflow_m, output)
-            self.current_file = dialog.path
+            current_file = dialog.path
+
+        with open(current_file, 'w') as output:
+            writer.write(self.workflow_m, output)
+            self.current_file = current_file
 
     def load_workflow(self):
         """ Shows a dialog to load a workflow file """

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -3,7 +3,6 @@ try:
     import mock
 except ImportError:
     from unittest import mock
-from contextlib import contextmanager
 
 from pyface.api import FileDialog, OK
 

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -3,6 +3,7 @@ try:
     import mock
 except ImportError:
     from unittest import mock
+from contextlib import contextmanager
 
 from pyface.api import FileDialog, OK
 
@@ -41,8 +42,17 @@ def mock_file_dialog(*args, **kwargs):
     return file_dialog
 
 
+def mock_file_dialog_being_closed(*args, **kwargs):
+    file_dialog = mock.Mock(spec=FileDialog)
+    file_dialog.open = lambda: False
+    file_dialog.path = ''
+    return file_dialog
+
+
+@contextmanager
 def mock_file_open(*args, **kwargs):
-    return ''
+    yield
+    return
 
 
 def mock_show_error(*args, **kwargs):
@@ -82,11 +92,12 @@ class TestWFManagerTask(unittest.TestCase):
                 mock.patch(FILE_OPEN_PATH) as mock_open, \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
             mock_dialog.side_effect = mock_file_dialog
-            mock_file_open.side_effect = mock_open
+            mock_open.side_effect = mock_file_open
             mock_writer.side_effect = mock_file_writer
 
             self.wfmanager_task.save_workflow()
             mock_writer.assert_called()
+            mock_open.assert_called()
             mock_dialog.assert_called()
 
             self.assertEqual(
@@ -98,19 +109,30 @@ class TestWFManagerTask(unittest.TestCase):
                 mock.patch(FILE_OPEN_PATH) as mock_open, \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
             mock_dialog.side_effect = mock_file_dialog
-            mock_file_open.side_effect = mock_open
+            mock_open.side_effect = mock_file_open
             mock_writer.side_effect = mock_file_writer
 
             self.wfmanager_task.save_workflow()
             mock_writer.assert_called()
+            mock_open.assert_called()
             mock_dialog.assert_not_called()
+
+    def test_close_saving_dialog(self):
+        with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
+                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
+            mock_dialog.side_effect = mock_file_dialog_being_closed
+            mock_open.side_effect = mock_file_open
+            mock_writer.side_effect = mock_file_writer
+
+            mock_open.assert_not_called()
 
     def test_load_workflow(self):
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
                 mock.patch(FILE_OPEN_PATH) as mock_open, \
                 mock.patch(WORKFLOW_READER_PATH) as mock_reader:
             mock_dialog.side_effect = mock_file_dialog
-            mock_file_open.side_effect = mock_open
+            mock_open.side_effect = mock_file_open
             mock_reader.side_effect = mock_file_reader
 
             old_workflow = self.wfmanager_task.workflow_m
@@ -126,7 +148,7 @@ class TestWFManagerTask(unittest.TestCase):
                 mock.patch(ERROR_PATH) as mock_error, \
                 mock.patch(WORKFLOW_READER_PATH) as mock_reader:
             mock_dialog.side_effect = mock_file_dialog
-            mock_file_open.side_effect = mock_open
+            mock_open.side_effect = mock_file_open
             mock_error.side_effect = mock_show_error
             mock_reader.side_effect = mock_file_reader_failure
 

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -37,7 +37,7 @@ def get_wfmanager_task():
 def mock_file_dialog(*args, **kwargs):
     file_dialog = mock.Mock(spec=FileDialog)
     file_dialog.open = lambda: OK
-    file_dialog.path = ''
+    file_dialog.path = 'file_path'
     return file_dialog
 
 
@@ -87,6 +87,23 @@ class TestWFManagerTask(unittest.TestCase):
 
             self.wfmanager_task.save_workflow()
             mock_writer.assert_called()
+            mock_dialog.assert_called()
+
+            self.assertEqual(
+                self.wfmanager_task.current_file,
+                'file_path'
+            )
+
+        with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
+                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
+            mock_dialog.side_effect = mock_file_dialog
+            mock_file_open.side_effect = mock_open
+            mock_writer.side_effect = mock_file_writer
+
+            self.wfmanager_task.save_workflow()
+            mock_writer.assert_called()
+            mock_dialog.assert_not_called()
 
     def test_load_workflow(self):
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -49,12 +49,6 @@ def mock_file_dialog_being_closed(*args, **kwargs):
     return file_dialog
 
 
-@contextmanager
-def mock_file_open(*args, **kwargs):
-    yield
-    return
-
-
 def mock_show_error(*args, **kwargs):
     return args
 
@@ -88,11 +82,11 @@ class TestWFManagerTask(unittest.TestCase):
         self.wfmanager_task = get_wfmanager_task()
 
     def test_save_workflow(self):
+        mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
-                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
             mock_dialog.side_effect = mock_file_dialog
-            mock_open.side_effect = mock_file_open
             mock_writer.side_effect = mock_file_writer
 
             self.wfmanager_task.save_workflow()
@@ -105,11 +99,11 @@ class TestWFManagerTask(unittest.TestCase):
                 'file_path'
             )
 
+        mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
-                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
             mock_dialog.side_effect = mock_file_dialog
-            mock_open.side_effect = mock_file_open
             mock_writer.side_effect = mock_file_writer
 
             self.wfmanager_task.save_workflow()
@@ -118,38 +112,39 @@ class TestWFManagerTask(unittest.TestCase):
             mock_dialog.assert_not_called()
 
     def test_close_saving_dialog(self):
+        mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
-                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
             mock_dialog.side_effect = mock_file_dialog_being_closed
-            mock_open.side_effect = mock_file_open
             mock_writer.side_effect = mock_file_writer
 
             self.wfmanager_task.save_workflow()
             mock_open.assert_not_called()
 
     def test_load_workflow(self):
+        mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
-                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_READER_PATH) as mock_reader:
             mock_dialog.side_effect = mock_file_dialog
-            mock_open.side_effect = mock_file_open
             mock_reader.side_effect = mock_file_reader
 
             old_workflow = self.wfmanager_task.workflow_m
 
             self.wfmanager_task.load_workflow()
 
+            mock_open.assert_called()
             mock_reader.assert_called()
             self.assertNotEqual(old_workflow, self.wfmanager_task.workflow_m)
 
     def test_load_failure(self):
+        mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
-                mock.patch(FILE_OPEN_PATH) as mock_open, \
+                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(ERROR_PATH) as mock_error, \
                 mock.patch(WORKFLOW_READER_PATH) as mock_reader:
             mock_dialog.side_effect = mock_file_dialog
-            mock_open.side_effect = mock_file_open
             mock_error.side_effect = mock_show_error
             mock_reader.side_effect = mock_file_reader_failure
 
@@ -157,6 +152,7 @@ class TestWFManagerTask(unittest.TestCase):
 
             self.wfmanager_task.load_workflow()
 
+            mock_open.assert_called()
             mock_reader.assert_called()
             mock_error.assert_called_with(
                 None,

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -159,3 +159,20 @@ class TestWFManagerTask(unittest.TestCase):
                 'Error when reading file'
             )
             self.assertEqual(old_workflow, self.wfmanager_task.workflow_m)
+
+    def test_open_failure(self):
+        mock_open = mock.mock_open()
+        mock_open.side_effect = IOError("OUPS")
+        with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
+                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
+                mock.patch(ERROR_PATH) as mock_error:
+            mock_dialog.side_effect = mock_file_dialog
+            mock_error.side_effect = mock_show_error
+
+            self.wfmanager_task.save_workflow()
+            mock_open.assert_called()
+            mock_error.assert_called_with(
+                None,
+                'Cannot save in the requested file:\n\nOUPS',
+                'Error when saving workflow'
+            )

--- a/test/test_wfmanager_task.py
+++ b/test/test_wfmanager_task.py
@@ -125,6 +125,7 @@ class TestWFManagerTask(unittest.TestCase):
             mock_open.side_effect = mock_file_open
             mock_writer.side_effect = mock_file_writer
 
+            self.wfmanager_task.save_workflow()
             mock_open.assert_not_called()
 
     def test_load_workflow(self):


### PR DESCRIPTION
We now keep in memory which file is currently edited, so that the application doesn't open a new dialog every time the user clicks on save