### PR TITLE
Remove possibility of closing the pane

### DIFF
--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -174,6 +174,9 @@ class WorkflowSettings(TraitsDockPane):
     id = 'force_wfmanager.workflow_settings'
     name = 'Workflow Settings'
 
+    #: Remove the ability of closing the pane
+    closable = False
+
     #: Available MCO factories
     available_mco_factories = List(Instance(BaseMCOFactory))
 


### PR DESCRIPTION
On MacOS it is not possible to retrieve the dock pane once it is closed, so we just remove the possibility of closing the pane.