### PR TITLE
Add Save as... action to the application

### DIFF
--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -118,7 +118,8 @@ class TestWFManagerTask(unittest.TestCase):
             mock_dialog.side_effect = mock_file_dialog
             mock_writer.side_effect = mock_file_writer
 
-            self.wfmanager_task.save_workflow()
+            self.wfmanager_task.save_workflow_as()
+
             mock_writer.assert_called()
             mock_open.assert_called()
             mock_dialog.assert_called()
@@ -136,6 +137,7 @@ class TestWFManagerTask(unittest.TestCase):
             mock_writer.side_effect = mock_file_writer
 
             self.wfmanager_task.save_workflow()
+
             mock_writer.assert_called()
             mock_open.assert_called()
             mock_dialog.assert_not_called()
@@ -234,7 +236,7 @@ class TestWFManagerTask(unittest.TestCase):
             mock_dialog.side_effect = mock_file_dialog
             mock_error.side_effect = mock_show_error
 
-            self.wfmanager_task.save_workflow()
+            self.wfmanager_task.save_workflow_as()
             mock_open.assert_called()
             mock_error.assert_called_with(
                 None,

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -142,6 +142,22 @@ class TestWFManagerTask(unittest.TestCase):
             mock_open.assert_called()
             mock_dialog.assert_not_called()
 
+    def test_save_workflow_without_current_file(self):
+        mock_open = mock.mock_open()
+        with mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
+                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
+            mock_writer.side_effect = mock_file_writer
+
+            self.wfmanager_task.save_workflow()
+
+            mock_writer.assert_not_called()
+            mock_open.assert_not_called()
+
+            self.assertEqual(
+                self.wfmanager_task.current_file,
+                ''
+            )
+
     def test_close_saving_dialog(self):
         mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -150,7 +150,7 @@ class TestWFManagerTask(unittest.TestCase):
             mock_dialog.side_effect = mock_file_dialog_being_closed
             mock_writer.side_effect = mock_file_writer
 
-            self.wfmanager_task.save_workflow()
+            self.wfmanager_task.save_workflow_as()
             mock_open.assert_not_called()
 
     def test_load_workflow(self):

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -53,7 +53,6 @@ class WfManagerTask(Task):
             name='Save Workflow',
             method='save_workflow',
             accelerator='Ctrl+S',
-            enabled_name='current_file',
         ),
         TaskAction(
             name='Save Workflow as...',
@@ -78,11 +77,13 @@ class WfManagerTask(Task):
         return [self.side_pane]
 
     def save_workflow(self):
-        """ Shows a dialog to save the workflow into a JSON file """
+        """ Saves the workflow into the currently used file. If there is no
+        current file, it shows a dialog """
         if len(self.current_file) == 0:
-            return
+            return self.save_workflow_as()
 
-        self._write_workflow(self.current_file)
+        if self._write_workflow(self.current_file) is False:
+            self.current_file = ''
 
     def save_workflow_as(self):
         """ Shows a dialog to save the workflow into a JSON file """

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -103,7 +103,19 @@ class WfManagerTask(Task):
 
     def _write_workflow(self, file_path):
         """ Creates a JSON file in the file_path and write the workflow
-        description in it """
+        description in it
+
+        Parameters
+        ----------
+        file_path: String
+            The file_path pointing to the file in which you want to write the
+            workflow
+
+        Returns
+        -------
+        Boolean:
+            True if it was a success to write in the file, False otherwise
+        """
         writer = WorkflowWriter()
         try:
             with open(file_path, 'w') as output:

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -129,6 +129,14 @@ class WfManagerTask(Task):
                 'Error when saving workflow'
             )
             return False
+        except Exception as e:
+            error(
+                None,
+                'Cannot save the workflow:\n\n{}'.format(
+                    str(e)),
+                'Error when saving workflow'
+            )
+            return False
         else:
             return True
 

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -19,6 +19,8 @@ from force_bdss.io.workflow_reader import WorkflowReader, InvalidFileException
 from force_wfmanager.central_pane.central_pane import CentralPane
 from force_wfmanager.left_side_pane.side_pane import SidePane
 
+log = logging.getLogger(__name__)
+
 
 @contextmanager
 def cleanup_garbage(tmpfile):
@@ -128,6 +130,7 @@ class WfManagerTask(Task):
                     str(e)),
                 'Error when saving workflow'
             )
+            log.exception('Error when saving workflow')
             return False
         except Exception as e:
             error(
@@ -136,6 +139,7 @@ class WfManagerTask(Task):
                     str(e)),
                 'Error when saving workflow'
             )
+            log.exception('Error when saving workflow')
             return False
         else:
             return True

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -84,7 +84,7 @@ class WfManagerTask(Task):
         if len(self.current_file) == 0:
             return self.save_workflow_as()
 
-        if self._write_workflow(self.current_file) is False:
+        if not self._write_workflow(self.current_file):
             self.current_file = ''
 
     def save_workflow_as(self):
@@ -101,7 +101,7 @@ class WfManagerTask(Task):
 
         current_file = dialog.path
 
-        if self._write_workflow(current_file) is True:
+        if self._write_workflow(current_file):
             self.current_file = current_file
 
     def _write_workflow(self, file_path):


### PR DESCRIPTION
Fixes #74 

The application has now "Save" and "Save as..." actions. The save action is disabled by default, and enabled only if a Workflow has already been loaded from a file, or the save as action has already been processed. The save as action can always be triggered, and will change the current file on which the application is currently writing.
