### PR TITLE
Move Analysis model outside the central pane and into the Task

### DIFF
--- a/force_wfmanager/central_pane/central_pane.py
+++ b/force_wfmanager/central_pane/central_pane.py
@@ -34,8 +34,9 @@ class CentralPane(TraitsTaskPane):
         )
     ))
 
-    def _analysis_model_default(self):
-        return AnalysisModel()
+    def __init__(self, analysis_model, *args, **kwargs):
+        super(CentralPane, self).__init__(*args, **kwargs)
+        self.analysis_model = analysis_model
 
     def _result_table_default(self):
         return ResultTable(

--- a/force_wfmanager/central_pane/tests/test_central_pane.py
+++ b/force_wfmanager/central_pane/tests/test_central_pane.py
@@ -1,11 +1,13 @@
 import unittest
 
+from force_wfmanager.central_pane.analysis_model import AnalysisModel
 from force_wfmanager.central_pane.central_pane import CentralPane
 
 
 class CentralPaneTest(unittest.TestCase):
     def setUp(self):
-        self.pane = CentralPane()
+        self.model = AnalysisModel()
+        self.pane = CentralPane(self.model)
 
     def test_pane_init(self):
         self.assertEqual(len(self.pane.analysis_model.value_names), 0)

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -1,4 +1,7 @@
 import unittest
+
+from force_wfmanager.central_pane.analysis_model import AnalysisModel
+
 try:
     import mock
 except ImportError:
@@ -109,6 +112,7 @@ class TestWFManagerTask(unittest.TestCase):
         self.assertIsInstance(
             self.wfmanager_task.side_pane.workflow_settings, WorkflowSettings)
         self.assertIsInstance(self.wfmanager_task.default_layout, TaskLayout)
+        self.assertIsInstance(self.wfmanager_task.analysis_m, AnalysisModel)
 
     def test_save_workflow(self):
         mock_open = mock.mock_open()

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -195,7 +195,7 @@ class WfManagerTask(Task):
     def _workflow_m_default(self):
         return Workflow()
 
-    def _analysis_model_default(self):
+    def _analysis_m_default(self):
         return AnalysisModel()
 
     def _side_pane_default(self):

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -16,6 +16,7 @@ from force_bdss.core.workflow import Workflow
 from force_bdss.io.workflow_writer import WorkflowWriter
 from force_bdss.io.workflow_reader import WorkflowReader, InvalidFileException
 
+from force_wfmanager.central_pane.analysis_model import AnalysisModel
 from force_wfmanager.central_pane.central_pane import CentralPane
 from force_wfmanager.left_side_pane.side_pane import SidePane
 
@@ -37,8 +38,12 @@ class WfManagerTask(Task):
     id = 'force_wfmanager.wfmanager_task'
     name = 'Workflow Manager'
 
-    #: Workflow model
+    #: Workflow model.
     workflow_m = Instance(Workflow, allow_none=False)
+
+    #: Analysis model. Contains the results that are displayed in the plot
+    #: and table
+    analysis_m = Instance(AnalysisModel, allow_none=False)
 
     #: Side Pane containing the tree editor for the Workflow and the Run button
     side_pane = Instance(SidePane)
@@ -72,7 +77,7 @@ class WfManagerTask(Task):
         """ Creates the central pane which contains the analysis part
         (pareto front and output KPI values)
         """
-        return CentralPane()
+        return CentralPane(self.analysis_m)
 
     def create_dock_panes(self):
         """ Creates the dock panes """
@@ -189,6 +194,9 @@ class WfManagerTask(Task):
 
     def _workflow_m_default(self):
         return Workflow()
+
+    def _analysis_model_default(self):
+        return AnalysisModel()
 
     def _side_pane_default(self):
         return SidePane(


### PR DESCRIPTION
It is convenient that the model is outside the UI element and into the Task, for later manipulation