### PR TITLE
Add evaluation step selection binding between table and plot

### DIFF
--- a/force_wfmanager/central_pane/central_pane.py
+++ b/force_wfmanager/central_pane/central_pane.py
@@ -2,7 +2,7 @@ from pyface.tasks.api import TraitsTaskPane
 
 from traits.api import Instance
 
-from traitsui.api import View, Tabbed, VGroup, UItem
+from traitsui.api import View, HGroup, VGroup, UItem
 
 from .analysis_model import AnalysisModel
 from .plot import Plot
@@ -23,15 +23,11 @@ class CentralPane(TraitsTaskPane):
     #: The plot view
     plot = Instance(Plot)
 
-    view = View(Tabbed(
-        VGroup(
-            UItem(name='result_table', style='custom'),
-            label='Result Table'
-        ),
-        VGroup(
+    view = View(VGroup(
+        HGroup(
+            UItem('result_table', style='custom'),
             UItem('plot', style='custom'),
-            label='Plot'
-        )
+        ),
     ))
 
     def __init__(self, analysis_model, *args, **kwargs):

--- a/force_wfmanager/central_pane/central_pane.py
+++ b/force_wfmanager/central_pane/central_pane.py
@@ -2,7 +2,7 @@ from pyface.tasks.api import TraitsTaskPane
 
 from traits.api import Instance
 
-from traitsui.api import View, HGroup, VGroup, UItem
+from traitsui.api import View, HSplit, VGroup, UItem
 
 from .analysis_model import AnalysisModel
 from .plot import Plot
@@ -24,7 +24,7 @@ class CentralPane(TraitsTaskPane):
     plot = Instance(Plot)
 
     view = View(VGroup(
-        HGroup(
+        HSplit(
             UItem('result_table', style='custom'),
             UItem('plot', style='custom'),
         ),

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -169,6 +169,7 @@ class Plot(HasStrictTraits):
 
     @on_trait_change('analysis_model.selected_step_index')
     def update_selected_point(self):
+        """ Updates the selected point in the plot according to the model """
         if self.analysis_model.selected_step_index is None:
             self._plot_index_datasource.metadata['selections'] = []
         else:
@@ -177,6 +178,7 @@ class Plot(HasStrictTraits):
 
     @on_trait_change('_plot_index_datasource.metadata_changed')
     def update_model(self):
+        """ Updates the model according to the selected point in the plot """
         selected_indices = self._plot_index_datasource.metadata.get(
             'selections', [])
         if len(selected_indices) == 0:

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -86,7 +86,7 @@ class Plot(HasStrictTraits):
             selection_line_width=3)
         scatter_plot.overlays.append(overlay)
 
-        # Add event listener for the selection
+        # Initialize plot datasource
         self._plot_index_datasource = scatter_plot.index
 
         return plot

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -1,9 +1,13 @@
 from traits.api import (HasStrictTraits, List, Instance, Enum, Property,
                         on_trait_change)
+
 from traitsui.api import View, UItem, Item, VGroup, HGroup
+
 from enable.api import Component, ComponentEditor
-from chaco.api import ArrayPlotData
+
+from chaco.api import ArrayPlotData, ScatterInspectorOverlay
 from chaco.api import Plot as ChacoPlot
+from chaco.tools.api import PanTool, ZoomTool, ScatterInspector
 
 from .analysis_model import AnalysisModel
 
@@ -47,7 +51,7 @@ class Plot(HasStrictTraits):
     def __plot_default(self):
         plot = ChacoPlot(self._plot_data)
 
-        plot.plot(
+        scatter_plot = plot.plot(
             ('x', 'y'),
             type="scatter",
             name="Plot",
@@ -57,9 +61,10 @@ class Plot(HasStrictTraits):
             marker_size=4,
             bgcolor="white")
 
-        plot.title = "Plot"
-        plot.line_width = 1
-        plot.padding = 50
+        plot.set(title="Plot", padding=50, line_width=1)
+
+        plot.tools.append(PanTool(plot))
+        plot.overlays.append(ZoomTool(plot))
 
         return plot
 

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -57,14 +57,31 @@ class Plot(HasStrictTraits):
             name="Plot",
             marker="circle",
             index_sort="ascending",
-            color="blue",
+            color="green",
             marker_size=4,
-            bgcolor="white")
+            bgcolor="white")[0]
 
         plot.set(title="Plot", padding=50, line_width=1)
 
+        # Add pan and zoom tools
         plot.tools.append(PanTool(plot))
         plot.overlays.append(ZoomTool(plot))
+
+        # Add the selection tool
+        scatter_plot.tools.append(ScatterInspector(
+            scatter_plot,
+            threshold=10,
+            selection_mode="single",
+        ))
+        overlay = ScatterInspectorOverlay(
+            scatter_plot,
+            hover_color="blue",
+            hover_marker_size=6,
+            selection_marker_size=6,
+            selection_color="blue",
+            selection_outline_color="blue",
+            selection_line_width=3)
+        scatter_plot.overlays.append(overlay)
 
         return plot
 

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -47,6 +47,7 @@ class ResultTable(HasStrictTraits):
 
     @on_trait_change('analysis_model.selected_step_index')
     def update_table(self):
+        """ Updates the selected row in the table according to the model """
         if self.analysis_model.selected_step_index is None:
             self._selected_rows = []
         else:
@@ -55,6 +56,7 @@ class ResultTable(HasStrictTraits):
 
     @on_trait_change('_selected_rows[]')
     def update_model(self):
+        """ Updates the model according to the selected row in the table """
         if len(self._selected_rows) == 0:
             self.analysis_model.selected_step_index = None
         else:

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -1,4 +1,4 @@
-from traits.api import (HasStrictTraits, List, Instance, Property, Tuple, Any,
+from traits.api import (HasStrictTraits, List, Instance, Property, Tuple,
                         on_trait_change, Either)
 
 from traitsui.api import View, UItem, TableEditor

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -23,7 +23,7 @@ class ResultTable(HasStrictTraits):
         depends_on='analysis_model.value_names'
     )
 
-    #: Selected evaluation step in the table
+    #: Selected evaluation steps in the table
     _selected_rows = Either(List(Tuple), None)
 
     view = View(

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -141,3 +141,28 @@ class PlotTest(unittest.TestCase):
 
         self.assertEqual(len(self.plot._data_arrays), 1)
         self.assertEqual(len(self.plot._data_arrays[0]), 0)
+
+    def test_selection(self):
+        self.analysis_model.value_names = ['density', 'pressure']
+        self.analysis_model.add_evaluation_step((1.010, 101325))
+        self.analysis_model.add_evaluation_step((1.100, 101423))
+        self.assertIsInstance(self.plot._plot, ChacoPlot)
+
+        plot_metadata = self.plot._plot_index_datasource.metadata
+
+        # From plot to the model
+        plot_metadata['selections'] = [1]
+        self.assertEqual(self.analysis_model.selected_step_index, 1)
+
+        plot_metadata['selections'] = [0]
+        self.assertEqual(self.analysis_model.selected_step_index, 0)
+
+        plot_metadata['selections'] = []
+        self.assertIsNone(self.analysis_model.selected_step_index)
+
+        # From model to the plot
+        self.analysis_model.selected_step_index = 1
+        self.assertEqual(plot_metadata['selections'], [1])
+
+        self.analysis_model.selected_step_index = None
+        self.assertEqual(plot_metadata['selections'], [])

--- a/force_wfmanager/central_pane/tests/test_result_table.py
+++ b/force_wfmanager/central_pane/tests/test_result_table.py
@@ -29,13 +29,22 @@ class ResultTableTest(unittest.TestCase):
         self.assertEqual(self.result_table.rows[2], (1.5, 50, 'CO'))
 
     def test_selection(self):
+        # From table to the model
         self.assertIsNone(self.analysis_model.selected_step_index)
 
-        self.result_table.selected_indices = [(0, 0), (0, 1), (0, 2)]
+        self.result_table._selected_rows = [(2.1, 56, 'CO')]
         self.assertEqual(self.analysis_model.selected_step_index, 0)
 
-        self.result_table.selected_indices = [(1, 0), (1, 1), (1, 2)]
+        self.result_table._selected_rows = [(1.23, 51.2, 'CO2')]
         self.assertEqual(self.analysis_model.selected_step_index, 1)
 
-        self.result_table.selected_indices = None
+        self.result_table._selected_rows = []
         self.assertIsNone(self.analysis_model.selected_step_index)
+
+        # From model to the table
+        self.analysis_model.selected_step_index = 1
+        self.assertEqual(self.result_table._selected_rows,
+                         [(1.23, 51.2, 'CO2')])
+
+        self.analysis_model.selected_step_index = None
+        self.assertEqual(self.result_table._selected_rows, [])


### PR DESCRIPTION
Fixes #92 

Add binding between the selected point in the plot and the selected row in the table. I also changed the layout of the central pane, the table is now next to the plot instead of in a separate tab.