### PR TITLE
Add confirmation dialog when clicking on the "Run" button

### DIFF
--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -277,6 +277,8 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
             self.assertEqual(old_workflow, self.wfmanager_task.workflow_m)
 
     def test_run_bdss(self):
+        self.wfmanager_task.analysis_m.value_names = ('x', )
+        self.wfmanager_task.analysis_m.add_evaluation_step((2.0, ))
         mock_open = mock.mock_open()
         with mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
                 mock.patch(FILE_OPEN_PATH, mock_open, create=True), \

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -280,10 +280,12 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
         self.wfmanager_task.analysis_m.value_names = ('x', )
         self.wfmanager_task.analysis_m.add_evaluation_step((2.0, ))
         mock_open = mock.mock_open()
-        with mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
+        with mock.patch(CONFIRM_PATH) as mock_confirm, \
+                mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
                 mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer, \
                 mock.patch(SUBPROCESS_PATH) as _mock_subprocess:
+            mock_confirm.side_effect = mock_confirm_function(YES)
             mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
             mock_writer.side_effect = mock_file_writer
             mock_subprocess.side_effect = mock_subprocess

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -10,7 +10,7 @@ from traits.api import Instance, on_trait_change, File, Str
 from pyface.tasks.api import Task, TaskLayout, PaneItem
 from pyface.tasks.action.api import SMenu, SMenuBar, TaskAction
 from pyface.api import (
-    FileDialog, OK, error, ConfirmationDialog, YES, CANCEL, GUI)
+    FileDialog, OK, error, ConfirmationDialog, YES, CANCEL, GUI, confirm)
 
 from force_bdss.factory_registry_plugin import FactoryRegistryPlugin
 from force_bdss.core.workflow import Workflow
@@ -187,6 +187,14 @@ class WfManagerTask(Task):
     @on_trait_change('side_pane.run_button')
     def run_bdss(self):
         """ Run the BDSS computation """
+        if len(self.analysis_m.evaluation_steps) != 0:
+            result = confirm(
+                None,
+                "Are you sure you want to run the computation and "
+                "empty the result table?")
+            if result is not YES:
+                return
+
         tmpfile_path = tempfile.mktemp()
 
         # Creates a temporary file containing the workflow


### PR DESCRIPTION
Prevents accidental deletion of the current non-empty table when clicking "run" on a new calculation, asking for confirmation.
