### PR TITLE
Fix the issue with the table row initialization

### DIFF
--- a/force_wfmanager/left_side_pane/evaluator_model_view.py
+++ b/force_wfmanager/left_side_pane/evaluator_model_view.py
@@ -30,6 +30,11 @@ class TableRow(HasStrictTraits):
         allow_none=False,
     )
 
+    def __init__(self, model, *args, **kwargs):
+        self.model = model
+
+        super(TableRow, self).__init__(*args, **kwargs)
+
 
 class InputSlotRow(TableRow):
     @on_trait_change('name')


### PR DESCRIPTION
When creating a slot row, given a name for the slot, it triggers the `name` listener before the instance is properly created. 

```
ERROR:traits:Exception occurred in traits notification handler for object: <force_wfmanager.left_side_pane.evaluator_model_view.OutputSlotRow object at 0x1257e0d00>, trait: name, old value: , new value: ptot
Traceback (most recent call last):
  File "/Users/sborini/.edm/envs/force35/lib/python3.5/site-packages/traits/trait_notifiers.py", line 519, in _dispatch_change_event
    self.dispatch( handler, *args )
  File "/Users/sborini/.edm/envs/force35/lib/python3.5/site-packages/traits/trait_notifiers.py", line 482, in dispatch
    handler( *args )
  File "/Users/sborini/Work/github/force-h2020/force-wfmanager/force_wfmanager/left_side_pane/evaluator_model_view.py", line 43, in update_model
    self.model.output_slot_names[self.index] = self.name
AttributeError: 'NoneType' object has no attribute 'output_slot_names'
```

We could fix this by using the `post_init` option on `on_trait_change`. I choose to reimplement the `__init__` and correctly set the model before handling any change.