### PR TITLE
Do not drop last point by inverting the socket check order.

### DIFF
--- a/force_wfmanager/server/zmq_server.py
+++ b/force_wfmanager/server/zmq_server.py
@@ -79,8 +79,8 @@ class ZMQServer(threading.Thread):
             events = dict(poller.poll())
 
             for socket_name, socket in [
-                    ("sync", self._sync_socket),
                     ("pub", self._pub_socket),
+                    ("sync", self._sync_socket),
                     ]:
 
                 if socket not in events:

--- a/force_wfmanager/tests/utils.py
+++ b/force_wfmanager/tests/utils.py
@@ -10,7 +10,7 @@ def wait_condition(condition, seconds=5):
     while True:
         if condition():
             break
-        time.sleep(1)
+        time.sleep(0.1)
         count += 1
-        if count == seconds:
+        if count == seconds*10:
             raise TimeoutError("timeout")


### PR DESCRIPTION
We were dropping the last point because the final pub and the sync goodbye
came at the same time, and the sync was examined first, leading to a state change
and thus to dropped data.