### PR TITLE
Synchronize the slot tables with the model

### DIFF
--- a/force_wfmanager/left_side_pane/evaluator_model_view.py
+++ b/force_wfmanager/left_side_pane/evaluator_model_view.py
@@ -37,12 +37,20 @@ class TableRow(HasStrictTraits):
 
 
 class InputSlotRow(TableRow):
+    @on_trait_change('model.input_slot_maps.name')
+    def update_view(self):
+        self.name = self.model.input_slot_maps[self.index].name
+
     @on_trait_change('name')
     def update_model(self):
         self.model.input_slot_maps[self.index].name = self.name
 
 
 class OutputSlotRow(TableRow):
+    @on_trait_change('model.output_slot_names[]')
+    def update_view(self):
+        self.name = self.model.output_slot_names[self.index]
+
     @on_trait_change('name')
     def update_model(self):
         self.model.output_slot_names[self.index] = self.name

--- a/force_wfmanager/left_side_pane/evaluator_model_view.py
+++ b/force_wfmanager/left_side_pane/evaluator_model_view.py
@@ -181,11 +181,13 @@ class EvaluatorModelView(ModelView):
         input_slots, output_slots = self._evaluator.slots(self.model)
 
         #: Initialize the input slots
+        self.input_slots_representation = []
         self.model.input_slot_maps = []
         for input_slot in input_slots:
             self.model.input_slot_maps.append(InputSlotMap(name=''))
 
         #: Initialize the output slots
+        self.output_slots_representation = []
         self.model.output_slot_names = len(output_slots)*['']
 
         self._fill_slot_rows(input_slots, output_slots)

--- a/force_wfmanager/left_side_pane/tests/test_evaluator_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_evaluator_model_view.py
@@ -112,3 +112,19 @@ class TestEvaluatorModelView(unittest.TestCase):
             self.evaluator_mv.output_slots_representation[0].type,
             "bar"
         )
+
+        self.model.output_slot_names = ['p1', 't1']
+        self.assertEqual(
+            self.evaluator_mv.output_slots_representation[0].name,
+            'p1'
+        )
+        self.assertEqual(
+            self.evaluator_mv.output_slots_representation[1].name,
+            't1'
+        )
+
+        self.model.input_slot_maps[0].name = 'p_in'
+        self.assertEqual(
+            self.evaluator_mv.input_slots_representation[0].name,
+            'p_in'
+        )


### PR DESCRIPTION
Synchronize the models with the slot tables.

This PR is a workaround for the issue #58, it doesn't fix the issue at all. But at least now the table shows to the user the correct current name of the slots.

This doesn't ensure that the type of the slot is synchronized with the model, but as "slots" method is not part of the model, we cannot know if the type changed.