### PR TITLE
Use a livemodal dialog when editing the model

### DIFF
--- a/force_wfmanager/left_side_pane/workflow_settings.py
+++ b/force_wfmanager/left_side_pane/workflow_settings.py
@@ -57,7 +57,8 @@ class WorkflowHandler(Handler):
 
     def edit_entity_handler(self, editor, object):
         """ Opens a dialog for configuring the workflow element """
-        object.model.edit_traits(kind="modal")
+        # This is a live dialog, workaround for issue #58
+        object.model.edit_traits(kind="livemodal")
 
     def delete_entity_handler(self, editor, object):
         """ Delete an element from the workflow """


### PR DESCRIPTION
This is a workaround for the issue #58. The UI now behave properly, and the model is correctly synchronized with the table view.
But it removes the possibility to discard the changes on the model by clicking on "Cancel"