### PR TITLE
Fix for missing variable name at initialization

### DIFF
--- a/force_wfmanager/left_side_pane/evaluator_model_view.py
+++ b/force_wfmanager/left_side_pane/evaluator_model_view.py
@@ -49,11 +49,11 @@ class InputSlotRow(TableRow):
     def update_view(self):
         self.name = self.model.input_slot_maps[self.index].name
 
-    @on_trait_change('name')
+    @on_trait_change('name', post_init=True)
     def update_model(self):
         self.model.input_slot_maps[self.index].name = self.name
 
-    @on_trait_change('available_variables')
+    @on_trait_change('available_variables', post_init=True)
     def update_combobox_values(self):
         self._combobox_values = [''] + self.available_variables
         self.name = ('' if self.name not in self.available_variables


### PR DESCRIPTION
In some cases, the variable names were not set post loading a file. This is due to ordering of traits execution at initialisation of the class with the default data.

Not adding tests as this code will eventually disappear when we move to multilayering.