### PR TITLE
Deletable data sources and extra KPI specification test

### DIFF
--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -24,6 +24,11 @@ class TestKPISpecificationModelViewTest(unittest.TestCase):
             variable_names_registry=self.registry
         )
 
+        self.kpi_specification_mv_named = KPISpecificationModelView(
+            model=KPISpecification(name='NamedKPI'),
+            variable_names_registry=self.registry
+        )
+
     def test_kpi_specification_mv_init(self):
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
 
@@ -44,3 +49,4 @@ class TestKPISpecificationModelViewTest(unittest.TestCase):
 
     def test_label(self):
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
+        self.assertEqual(self.kpi_specification_mv_named.label, "KPI: NamedKPI")

--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -49,4 +49,5 @@ class TestKPISpecificationModelViewTest(unittest.TestCase):
 
     def test_label(self):
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
-        self.assertEqual(self.kpi_specification_mv_named.label, "KPI: NamedKPI")
+        self.assertEqual(self.kpi_specification_mv_named.label,
+                         "KPI: NamedKPI")

--- a/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
@@ -8,15 +8,26 @@ from force_bdss.tests.probe_classes.notification_listener import \
     ProbeNotificationListenerFactory
 from force_bdss.tests.probe_classes.probe_extension_plugin import \
     ProbeExtensionPlugin
+
 from force_wfmanager.left_side_pane.workflow_model_view import \
     WorkflowModelView
-
+from force_wfmanager.left_side_pane.variable_names_registry import \
+    VariableNamesRegistry
+from force_bdss.tests.probe_classes.data_source import (ProbeDataSourceFactory,
+ProbeDataSource,ProbeDataSourceModel)
 
 # change
 class TestWorkflowModelView(unittest.TestCase):
     def setUp(self):
         self.wf_mv = WorkflowModelView(model=Workflow())
+        workflow = Workflow()
+        name_registry = VariableNamesRegistry(workflow)
+        self.wf_mv_name_registry = WorkflowModelView(model=workflow,
+                                                     variable_names_registry=
+                                                     name_registry)
         self.plugin = ProbeExtensionPlugin()
+        self.datasource_model = ProbeDataSourceModel(factory=ProbeDataSourceFactory(
+            plugin=self.plugin))
 
     def test_add_execution_layer(self):
         self.assertEqual(len(self.wf_mv.execution_layers_mv), 0)
@@ -51,3 +62,15 @@ class TestWorkflowModelView(unittest.TestCase):
         self.assertEqual(len(self.wf_mv.notification_listeners_mv), 1)
         self.wf_mv.remove_notification_listener(model)
         self.assertEqual(len(self.wf_mv.notification_listeners_mv), 0)
+
+    def test_remove_datasource(self):
+        self.wf_mv_name_registry.add_execution_layer(ExecutionLayer())
+        self.assertEqual(len(self.wf_mv_name_registry.
+                             execution_layers_mv[0].model.data_sources), 0)
+        self.wf_mv_name_registry.execution_layers_mv[0].\
+            add_data_source(self.datasource_model)
+        self.assertEqual(len(self.wf_mv_name_registry.
+                             execution_layers_mv[0].model.data_sources), 1)
+        self.wf_mv_name_registry.remove_data_source(self.datasource_model)
+        self.assertEqual(len(self.wf_mv_name_registry.
+                             execution_layers_mv[0].model.data_sources), 0)

--- a/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
@@ -68,13 +68,10 @@ class TestWorkflowModelView(unittest.TestCase):
         self.wf_mv_name_registry.add_execution_layer(ExecutionLayer())
         self.assertEqual(len(self.wf_mv_name_registry.
                              execution_layers_mv[0].model.data_sources), 0)
-        self.wf_mv_name_registry.execution_layers_mv[0].\
-            add_data_source(self.datasource_models[0])
-        self.assertEqual(len(self.wf_mv_name_registry.
-                             execution_layers_mv[0].model.data_sources), 1)
+        execution_layer = self.wf_mv_name_registry.execution_layers_mv[0]
+        execution_layer.add_data_source(self.datasource_models[0])
+        self.assertEqual(len(execution_layer.model.data_sources), 1)
         self.wf_mv_name_registry.remove_data_source(self.datasource_models[1])
-        self.assertEqual(len(self.wf_mv_name_registry.
-                             execution_layers_mv[0].model.data_sources), 1)
+        self.assertEqual(len(execution_layer.model.data_sources), 1)
         self.wf_mv_name_registry.remove_data_source(self.datasource_models[0])
-        self.assertEqual(len(self.wf_mv_name_registry.
-                             execution_layers_mv[0].model.data_sources), 0)
+        self.assertEqual(len(execution_layer.model.data_sources), 0)

--- a/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
@@ -14,20 +14,20 @@ from force_wfmanager.left_side_pane.workflow_model_view import \
 from force_wfmanager.left_side_pane.variable_names_registry import \
     VariableNamesRegistry
 from force_bdss.tests.probe_classes.data_source import (ProbeDataSourceFactory,
-ProbeDataSource,ProbeDataSourceModel)
-
+                                                        ProbeDataSourceModel)
 # change
+
+
 class TestWorkflowModelView(unittest.TestCase):
     def setUp(self):
         self.wf_mv = WorkflowModelView(model=Workflow())
         workflow = Workflow()
         name_registry = VariableNamesRegistry(workflow)
-        self.wf_mv_name_registry = WorkflowModelView(model=workflow,
-                                                     variable_names_registry=
-                                                     name_registry)
+        self.wf_mv_name_registry = WorkflowModelView(
+            model=workflow, variable_names_registry=name_registry)
         self.plugin = ProbeExtensionPlugin()
-        self.datasource_model = ProbeDataSourceModel(factory=ProbeDataSourceFactory(
-            plugin=self.plugin))
+        self.datasource_model = ProbeDataSourceModel(
+            factory=ProbeDataSourceFactory(plugin=self.plugin))
 
     def test_add_execution_layer(self):
         self.assertEqual(len(self.wf_mv.execution_layers_mv), 0)

--- a/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_workflow_model_view.py
@@ -26,8 +26,9 @@ class TestWorkflowModelView(unittest.TestCase):
         self.wf_mv_name_registry = WorkflowModelView(
             model=workflow, variable_names_registry=name_registry)
         self.plugin = ProbeExtensionPlugin()
-        self.datasource_model = ProbeDataSourceModel(
+        self.datasource_models = [ProbeDataSourceModel(
             factory=ProbeDataSourceFactory(plugin=self.plugin))
+            for _ in range(2)]
 
     def test_add_execution_layer(self):
         self.assertEqual(len(self.wf_mv.execution_layers_mv), 0)
@@ -68,9 +69,12 @@ class TestWorkflowModelView(unittest.TestCase):
         self.assertEqual(len(self.wf_mv_name_registry.
                              execution_layers_mv[0].model.data_sources), 0)
         self.wf_mv_name_registry.execution_layers_mv[0].\
-            add_data_source(self.datasource_model)
+            add_data_source(self.datasource_models[0])
         self.assertEqual(len(self.wf_mv_name_registry.
                              execution_layers_mv[0].model.data_sources), 1)
-        self.wf_mv_name_registry.remove_data_source(self.datasource_model)
+        self.wf_mv_name_registry.remove_data_source(self.datasource_models[1])
+        self.assertEqual(len(self.wf_mv_name_registry.
+                             execution_layers_mv[0].model.data_sources), 1)
+        self.wf_mv_name_registry.remove_data_source(self.datasource_models[0])
         self.assertEqual(len(self.wf_mv_name_registry.
                              execution_layers_mv[0].model.data_sources), 0)

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -52,6 +52,12 @@ class WorkflowModelView(ModelView):
         """Removes the execution layer from the model."""
         self.model.notification_listeners.remove(notification_listener)
 
+    def remove_data_source(self, data_source):
+        """Removes the data source from the model"""
+        for execution_layer in self.model.execution_layers:
+            if data_source in execution_layer.data_sources:
+                execution_layer.data_sources.remove(data_source)
+
     # Update the model views in response to changes in the model structure.
 
     @on_trait_change('model.mco')

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -54,9 +54,9 @@ class WorkflowModelView(ModelView):
 
     def remove_data_source(self, data_source):
         """Removes the data source from the model"""
-        for execution_layer in self.model.execution_layers:
-            if data_source in execution_layer.data_sources:
-                execution_layer.data_sources.remove(data_source)
+        for execution_layer_mv in self.execution_layers_mv:
+            if data_source in execution_layer_mv.model.data_sources:
+                execution_layer_mv.remove_data_source(data_source)
 
     # Update the model views in response to changes in the model structure.
 

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -109,7 +109,7 @@ class WfManagerTask(Task):
         ),
         SMenu(
             TaskAction(
-                name='About WorflowManager...',
+                name='About WorkflowManager...',
                 method='open_about'
             ),
             name='&Help'


### PR DESCRIPTION
Originally, deleting a datasource called a unwritten function in workflow_model_view. There is also an extra test for a named KPI, as we were only checking the default one before.
The KPI issue comes from the merge with master, but since this is such a small commit the single line of code not checked was causing the coverage checks to fail!