### PR TITLE
163 kpi name saves - partial

### DIFF
--- a/force_wfmanager/left_side_pane/kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/kpi_specification_model_view.py
@@ -43,6 +43,11 @@ class KPISpecificationModelView(ModelView):
     def _label_default(self):
         return _get_label(self.model)
 
+    @on_trait_change('name')
+    def update_model(self):
+        if self.model is not None:
+            self.model.name = self.name
+
     @on_trait_change('variable_names_registry.data_source_outputs')
     def update_combobox_values(self):
         available = self.variable_names_registry.data_source_outputs

--- a/force_wfmanager/left_side_pane/kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/kpi_specification_model_view.py
@@ -44,7 +44,7 @@ class KPISpecificationModelView(ModelView):
     def _label_default(self):
         return _get_label(self.model)
 
-    @on_trait_change('name',post_init=True)
+    @on_trait_change('name', post_init=True)
     def update_model(self):
         self.model.name = self.name
 

--- a/force_wfmanager/left_side_pane/kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/kpi_specification_model_view.py
@@ -1,5 +1,5 @@
 from traits.api import Instance, Str, Bool, Enum, List, on_trait_change
-from traitsui.api import ModelView, View, Item
+from traitsui.api import ModelView, View, Item, EnumEditor
 
 from force_bdss.core.kpi_specification import KPISpecification
 from force_bdss.local_traits import Identifier
@@ -28,7 +28,7 @@ class KPISpecificationModelView(ModelView):
 
     #: Base view for the MCO parameter
     traits_view = View(
-        Item("name"),
+        Item('model.name', editor=EnumEditor(name='object._combobox_values')),
         Item("model.objective"),
         kind="subpanel",
     )
@@ -39,14 +39,9 @@ class KPISpecificationModelView(ModelView):
             variable_names_registry=variable_names_registry,
             **kwargs
         )
-        model.name = self.name
 
     def _label_default(self):
         return _get_label(self.model)
-
-    @on_trait_change('name', post_init=True)
-    def update_model(self):
-        self.model.name = self.name
 
     @on_trait_change('variable_names_registry.data_source_outputs')
     def update_combobox_values(self):

--- a/force_wfmanager/left_side_pane/kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/kpi_specification_model_view.py
@@ -39,14 +39,14 @@ class KPISpecificationModelView(ModelView):
             variable_names_registry=variable_names_registry,
             **kwargs
         )
+        model.name = self.name
 
     def _label_default(self):
         return _get_label(self.model)
 
-    @on_trait_change('name')
+    @on_trait_change('name',post_init=True)
     def update_model(self):
-        if self.model is not None:
-            self.model.name = self.name
+        self.model.name = self.name
 
     @on_trait_change('variable_names_registry.data_source_outputs')
     def update_combobox_values(self):

--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -1,5 +1,4 @@
 import unittest
-import mock
 
 from force_bdss.core.output_slot_info import OutputSlotInfo
 from force_wfmanager.left_side_pane.tests.test_variable_names_registry import \
@@ -9,10 +8,6 @@ from force_bdss.core.kpi_specification import KPISpecification
 from force_wfmanager.left_side_pane.kpi_specification_model_view import \
     KPISpecificationModelView
 
-def mock_kpi_no_model():
-    kpi_no_model = mock.Mock(spec=KPISpecificationModelView)
-    kpi_no_model.model = None
-    return kpi_no_model
 
 class TestKPISpecificationModelViewTest(unittest.TestCase):
     def setUp(self):
@@ -53,8 +48,7 @@ class TestKPISpecificationModelViewTest(unittest.TestCase):
     def test_update_model(self):
         self.assertEqual(self.kpi_specification_mv.model.name,
                          self.kpi_specification_mv.name)
-        self.kpi_specification_mv._combobox_values = ['','TestName']
+        self.kpi_specification_mv._combobox_values = ['', 'TestName']
         self.kpi_specification_mv.name = 'TestName'
         self.assertEqual(self.kpi_specification_mv.model.name,
                          self.kpi_specification_mv.name)
-        

--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -44,11 +44,3 @@ class TestKPISpecificationModelViewTest(unittest.TestCase):
 
     def test_label(self):
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
-
-    def test_update_model(self):
-        self.assertEqual(self.kpi_specification_mv.model.name,
-                         self.kpi_specification_mv.name)
-        self.kpi_specification_mv._combobox_values = ['', 'TestName']
-        self.kpi_specification_mv.name = 'TestName'
-        self.assertEqual(self.kpi_specification_mv.model.name,
-                         self.kpi_specification_mv.name)

--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -1,4 +1,5 @@
 import unittest
+import mock
 
 from force_bdss.core.output_slot_info import OutputSlotInfo
 from force_wfmanager.left_side_pane.tests.test_variable_names_registry import \
@@ -8,6 +9,10 @@ from force_bdss.core.kpi_specification import KPISpecification
 from force_wfmanager.left_side_pane.kpi_specification_model_view import \
     KPISpecificationModelView
 
+def mock_kpi_no_model():
+    kpi_no_model = mock.Mock(spec=KPISpecificationModelView)
+    kpi_no_model.model = None
+    return kpi_no_model
 
 class TestKPISpecificationModelViewTest(unittest.TestCase):
     def setUp(self):
@@ -44,3 +49,12 @@ class TestKPISpecificationModelViewTest(unittest.TestCase):
 
     def test_label(self):
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
+
+    def test_update_model(self):
+        self.assertEqual(self.kpi_specification_mv.model.name,
+                         self.kpi_specification_mv.name)
+        self.kpi_specification_mv._combobox_values = ['','TestName']
+        self.kpi_specification_mv.name = 'TestName'
+        self.assertEqual(self.kpi_specification_mv.model.name,
+                         self.kpi_specification_mv.name)
+        

--- a/force_wfmanager/left_side_pane/tests/test_mco_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_mco_model_view.py
@@ -8,6 +8,10 @@ from force_wfmanager.left_side_pane.mco_model_view import MCOModelView
 from force_wfmanager.left_side_pane.mco_parameter_model_view import \
     MCOParameterModelView
 
+from force_wfmanager.left_side_pane.variable_names_registry import \
+    VariableNamesRegistry
+from force_wfmanager.left_side_pane.workflow_tree import Workflow
+
 
 class TestMCOModelView(unittest.TestCase):
     def setUp(self):
@@ -16,8 +20,9 @@ class TestMCOModelView(unittest.TestCase):
         model = factory.create_model()
         parameter_factory = factory.parameter_factories()[0]
         model.parameters = [parameter_factory.create_model()]
-
-        self.mco_mv = MCOModelView(model=model)
+        var_names = VariableNamesRegistry(workflow=Workflow())
+        self.mco_mv = MCOModelView(model=model,
+                                   variable_names_registry=var_names)
 
     def test_mco_parameter_representation(self):
         self.assertEqual(
@@ -35,6 +40,5 @@ class TestMCOModelView(unittest.TestCase):
         self.mco_mv.add_kpi(kpi_spec)
         self.assertEqual(len(self.mco_mv.kpis_mv), 1)
         self.assertEqual(self.mco_mv.kpis_mv[0].model, kpi_spec)
-
         self.mco_mv.remove_kpi(kpi_spec)
         self.assertEqual(len(self.mco_mv.kpis_mv), 0)


### PR DESCRIPTION
Made kpi model track the name of the associated modelviewer. This prevents an error where nameless kpis would not be returned as output.
Also some slight changes to the MCO model viewer tests, as we now assign a name to the kpi model on initialisation. In a real run of the program this is passed as an argument to the kpi modelviewer, so the test was updated to reflect that.

This pr doesn't yet address the saving/loading behaviour, but I'd like to get it merged anyway as you can't run a computation in the workflow manager without this fix.