### PR TITLE
163 fixed names not loading for datasources

### DIFF
--- a/force_wfmanager/left_side_pane/data_source_model_view.py
+++ b/force_wfmanager/left_side_pane/data_source_model_view.py
@@ -230,7 +230,7 @@ class DataSourceModelView(ModelView):
         for index, input_slot in enumerate(input_slots):
             slot_representation = InputSlotRow(model=self.model, index=index)
             new_name = self.model.input_slot_info[index].name
-            if new_name in available_variables:
+            if new_name not in available_variables:
                 new_name = ''
 
             slot_representation.available_variables = available_variables

--- a/force_wfmanager/left_side_pane/data_source_model_view.py
+++ b/force_wfmanager/left_side_pane/data_source_model_view.py
@@ -228,12 +228,13 @@ class DataSourceModelView(ModelView):
         input_representations = []
 
         for index, input_slot in enumerate(input_slots):
-            new_name = self.model.input_slot_info[index].name
             slot_representation = InputSlotRow(model=self.model, index=index)
-            new_name = (new_name if new_name in available_variables else '')
+            new_name = self.model.input_slot_info[index].name
+            if new_name in available_variables:
+                new_name = ''
+
             slot_representation.available_variables = available_variables
             slot_representation.name = new_name
-
             slot_representation.type = input_slot.type
 
             input_representations.append(slot_representation)


### PR DESCRIPTION
When creating a workflow from a json file, the program uses this file to create the model - which should then automatically update the workflow model view. 
However with datasource names there was an issue where the Input row in the model view could not be assigned a name without first being assigned a list of available (name) variables. This then called functions designed to a) enusure the name was in available names  and b) enforce consistency between the modelview and model. The program essentially acted as if a user had selected the default name from the ui.
The fix was just to check a) elsewhere, in a way which did not trigger b) immediately.
Sorry for the long description, but it's such a small fix for a complicated (at least for me!) problem I felt it made sense to give some context.