### PR TITLE
Workaround for exceptions on closing wfmanager

### DIFF
--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -405,7 +405,12 @@ class WfManagerTask(Task):
         elif result is CANCEL:
             return
 
-        self.window.application.exit()
+        app = self.window.application
+        window = self.window
+
+        window.remove_task(self)
+        window.close()
+        app.exit()
 
     # Default initializers
 


### PR DESCRIPTION
Addresses #75. This workaround removes the task from the window before calling the usual close method(s) - since there are now no UItems to require a sizehint() the exception is no longer raised.