### PR TITLE
KPI Label not being unset

### DIFF
--- a/force_wfmanager/left_side_pane/kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/kpi_specification_model_view.py
@@ -44,7 +44,21 @@ class KPISpecificationModelView(ModelView):
     def update_combobox_values(self):
         available = self.variable_names_registry.data_source_outputs
         self._combobox_values = [''] + available
+
         self.name = ('' if self.name not in available else self.name)
+
+        # If the KPI choice is no longer valid, change the model as well as
+        # the view. This does not happen automatically when model.name is
+        # set to a value not in _combobox_values
+        if self.model is not None and self.name == '':
+            self.model.name = ''
+
+    @on_trait_change('model.name')
+    def update_name(self):
+        if self.model is None:
+            self.name = ''
+        else:
+            self.name = self.model.name
 
     @cached_property
     def _get_label(self):

--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -25,11 +25,6 @@ class TestKPISpecificationModelViewTest(unittest.TestCase, UnittestTools):
             variable_names_registry=self.registry
         )
 
-        self.kpi_specification_mv_named = KPISpecificationModelView(
-            model=KPISpecification(name='NamedKPI'),
-            variable_names_registry=self.registry
-        )
-
     def test_kpi_specification_mv_init(self):
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
 
@@ -49,9 +44,15 @@ class TestKPISpecificationModelViewTest(unittest.TestCase, UnittestTools):
                          ['', 'T1', 'T2'])
 
     def test_label(self):
+        self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
+
         self.assertEqual(self.kpi_specification_mv.label, "KPI")
+        self.kpi_specification_mv_named = KPISpecificationModelView(
+            model=KPISpecification(name='T1'),
+            variable_names_registry=self.registry
+        )
         self.assertEqual(self.kpi_specification_mv_named.label,
-                         "KPI: NamedKPI")
+                         "KPI: T1")
 
     def test_name_change(self):
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]


### PR DESCRIPTION
Addreses #196. Fixes an error where kpi_mv.name would never actually be set, and checks for kpi_mv.model.name being set to ''. This could happen automatically if the thing model.name was already set to was removed from the list of available variables. This would set kpi_mv.model.name = ''.
However, properties which depended on model.name did not seem to track this change.