### PR TITLE
Plot Display Resizing

### DIFF
--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -72,7 +72,7 @@ class Plot(HasStrictTraits):
             marker_size=4,
             bgcolor="white")[0]
 
-        plot.set(title="Plot", padding=50, line_width=1)
+        plot.set(title="Plot", padding=75, line_width=1)
 
         # Add pan and zoom tools
         plot.tools.append(PanTool(plot))

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -180,7 +180,7 @@ class Plot(HasStrictTraits):
         """Set the plot data model to the appropriate arrays so that they
         can be displayed when either X or Y selections have been changed.
         """
-        if self.x is None or self.y is None:
+        if self.x is None or self.y is None or self._data_arrays == []:
             self._plot_data.set_data('x', [])
             self._plot_data.set_data('y', [])
             return
@@ -188,11 +188,10 @@ class Plot(HasStrictTraits):
         x_index = self.analysis_model.value_names.index(self.x)
         y_index = self.analysis_model.value_names.index(self.y)
 
-        if self._data_arrays != []:
-            self._plot_data.set_data('x', self._data_arrays[x_index])
-            self._plot_data.set_data('y', self._data_arrays[y_index])
+        self._plot_data.set_data('x', self._data_arrays[x_index])
+        self._plot_data.set_data('y', self._data_arrays[y_index])
 
-            self.resize_plot()
+        self.resize_plot()
 
     def resize_plot(self):
         """ Sets the size of the current plot to have some spacing between the
@@ -220,6 +219,14 @@ class Plot(HasStrictTraits):
             y_min = y_min - 0.1 * abs(y_size)
 
             self.set_plot_range(x_min, x_max, y_min, y_max)
+
+            # Replace the old ZoomTool as retaining the same one can lead
+            # to issues where the zoom out/in limit is not reset on
+            # resizing the plot.
+
+            for idx, overlay in enumerate(self._plot.overlays):
+                if isinstance(overlay, ZoomTool):
+                    self._plot.overlays[idx] = ZoomTool(self._plot)
 
             return x_min, x_max, y_min, y_max
         return None

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -262,7 +262,7 @@ class Plot(HasStrictTraits):
 
     def set_plot_range(self, x_low, x_high, y_low, y_high):
         """Helper method to set the size of the current _plot"""
-        self._plot.range2d.x_range.low = x_low
-        self._plot.range2d.x_range.high = x_high
-        self._plot.range2d.y_range.low = y_low
-        self._plot.range2d.y_range.high = y_high
+        self._plot.range2d.x_range.low_setting = x_low
+        self._plot.range2d.x_range.high_setting = x_high
+        self._plot.range2d.y_range.low_setting = y_low
+        self._plot.range2d.y_range.high_setting = y_high

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -47,7 +47,9 @@ class Plot(HasStrictTraits):
             Item('y'),
         ),
         UItem('_plot', editor=ComponentEditor()),
-        UItem('reset_plot', enabled_when='reset_enabled')
+        VGroup(
+            UItem('reset_plot', enabled_when='reset_enabled')
+        )
     ))
 
     def __init__(self, analysis_model, *args, **kwargs):
@@ -180,16 +182,21 @@ class Plot(HasStrictTraits):
         x_index = self.analysis_model.value_names.index(self.x)
         y_index = self.analysis_model.value_names.index(self.y)
 
-        self._plot_data.set_data('x', self._data_arrays[x_index])
-        self._plot_data.set_data('y', self._data_arrays[y_index])
+        if self._data_arrays != []:
+            self._plot_data.set_data('x', self._data_arrays[x_index])
+            self._plot_data.set_data('y', self._data_arrays[y_index])
 
-        self.resize_plot()
+            self.resize_plot()
 
     def resize_plot(self):
 
+        if self.x is None or self.y is None:
+            return
+
         x_data = self._plot_data.get_data('x')
         y_data = self._plot_data.get_data('y')
-
+        if x_data is None:
+            return
         if len(x_data) > 1:
             x_max = max(x_data)
             x_min = min(x_data)
@@ -232,6 +239,9 @@ class Plot(HasStrictTraits):
         self.resize_plot()
 
     def _get_reset_enabled(self):
-        if len(self._plot_data.get_data('x')) > 1:
+        x_data = self._plot_data.get_data('x')
+        if x_data is None:
+            return False
+        if len(x_data) > 1:
             return True
         return False

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -116,6 +116,12 @@ class Plot(HasStrictTraits):
         if len(self._value_names) > 1:
             self.y = self._value_names[1]
 
+        # If there are no available value names, set the plot view to a default
+        # state. This occurs when the analysis model is cleared.
+
+        if self._value_names == ():
+            self.set_plot_range(-1, 1, -1, 1)
+
     @on_trait_change('analysis_model.evaluation_steps[]')
     def update_data_arrays(self):
         """ Update the data arrays used by the plot. It assumes that the
@@ -213,10 +219,7 @@ class Plot(HasStrictTraits):
             y_max = y_max + 0.1 * abs(y_size)
             y_min = y_min - 0.1 * abs(y_size)
 
-            self._plot.range2d.x_range.low = x_min
-            self._plot.range2d.x_range.high = x_max
-            self._plot.range2d.y_range.low = y_min
-            self._plot.range2d.y_range.high = y_max
+            self.set_plot_range(x_min, x_max, y_min, y_max)
 
             return x_min, x_max, y_min, y_max
         return None
@@ -249,3 +252,10 @@ class Plot(HasStrictTraits):
         if len(x_data) > 1:
             return True
         return False
+
+    def set_plot_range(self, x_low, x_high, y_low, y_high):
+        """Helper method to set the size of the current _plot"""
+        self._plot.range2d.x_range.low = x_low
+        self._plot.range2d.x_range.high = x_high
+        self._plot.range2d.y_range.low = y_low
+        self._plot.range2d.y_range.high = y_high

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -189,10 +189,11 @@ class Plot(HasStrictTraits):
             self.resize_plot()
 
     def resize_plot(self):
-        """Sets the size of the current plot to have some spacing between the
+        """ Sets the size of the current plot to have some spacing between the
         largest/smallest value and the plot edge. Also returns the new values
         (X min, X max, Y min, Y max) if the plot area changes or None if it
-         does not."""
+        does not.
+        """
         if self.x is None or self.y is None:
             return None
 

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -232,6 +232,8 @@ class Plot(HasStrictTraits):
 
             self.set_plot_range(x_min, x_max, y_min, y_max)
 
+            return x_min, x_max, y_min, y_max
+
         elif len(x_data) == 1:
             self.set_plot_range(x_data[0] - 0.5, x_data[0] + 0.5,
                                 y_data[0] - 0.5, y_data[0] + 0.5)
@@ -244,7 +246,8 @@ class Plot(HasStrictTraits):
                 if isinstance(overlay, ZoomTool):
                     self._plot.overlays[idx] = ZoomTool(self._plot)
 
-            return x_min, x_max, y_min, y_max
+            return (x_data[0] - 0.5, x_data[0] + 0.5, y_data[0] - 0.5,
+                    y_data[0] + 0.5)
         return None
 
     @on_trait_change('analysis_model.selected_step_index')

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -39,7 +39,7 @@ class Plot(HasStrictTraits):
     #: Button to reset plot view
     reset_plot = Button('Reset View')
 
-    reset_enabled = Property(Bool(False), depends_on="_plot_data")
+    reset_enabled = Property(Bool(), depends_on="_plot_data")
 
     view = View(VGroup(
         HGroup(

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -189,14 +189,18 @@ class Plot(HasStrictTraits):
             self.resize_plot()
 
     def resize_plot(self):
-
+        """Sets the size of the current plot to have some spacing between the
+        largest/smallest value and the plot edge. Also returns the new values
+        (X min, X max, Y min, Y max) if the plot area changes or None if it
+         does not."""
         if self.x is None or self.y is None:
-            return
+            return None
 
         x_data = self._plot_data.get_data('x')
         y_data = self._plot_data.get_data('y')
         if x_data is None:
-            return
+            return None
+
         if len(x_data) > 1:
             x_max = max(x_data)
             x_min = min(x_data)
@@ -214,6 +218,9 @@ class Plot(HasStrictTraits):
             self._plot.range2d.x_range.high = x_max
             self._plot.range2d.y_range.low = y_min
             self._plot.range2d.y_range.high = y_max
+
+            return x_min, x_max, y_min, y_max
+        return None
 
     @on_trait_change('analysis_model.selected_step_index')
     def update_selected_point(self):

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -199,8 +199,6 @@ class Plot(HasStrictTraits):
 
         x_data = self._plot_data.get_data('x')
         y_data = self._plot_data.get_data('y')
-        if x_data is None:
-            return None
 
         if len(x_data) > 1:
             x_max = max(x_data)
@@ -248,8 +246,6 @@ class Plot(HasStrictTraits):
 
     def _get_reset_enabled(self):
         x_data = self._plot_data.get_data('x')
-        if x_data is None:
-            return False
         if len(x_data) > 1:
             return True
         return False

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -187,9 +187,6 @@ class Plot(HasStrictTraits):
 
     def resize_plot(self):
 
-        print(self.analysis_model)
-        print(self.analysis_model.value_names)
-
         x_data = self._plot_data.get_data('x')
         y_data = self._plot_data.get_data('y')
 

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -6,6 +6,7 @@ from chaco.api import Plot as ChacoPlot
 from force_wfmanager.central_pane.analysis_model import AnalysisModel
 from force_wfmanager.central_pane.plot import Plot
 from traits.api import push_exception_handler
+
 push_exception_handler(reraise_exceptions=True)
 
 
@@ -193,3 +194,6 @@ class TestPlot(unittest.TestCase):
         result = self.plot.resize_plot()
         self.assertEqual(result, (1.9, 3.1, 2.9, 4.1))
         self.assertTrue(self.plot._get_reset_enabled())
+        self.plot._plot.range2d.x_range.low = -10
+        self.plot.reset_plot = True
+        self.assertEqual(self.plot._plot.range2d.x_range.low, 1.9)

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -186,8 +186,8 @@ class TestPlot(unittest.TestCase):
         self.analysis_model.value_names = ('x', 'y')
         self.analysis_model.add_evaluation_step((2, 3))
         result = self.plot.resize_plot()
-        self.assertIsNone(result)
-        self.assertFalse(self.plot._get_reset_enabled())
+        self.assertEqual(result, (1.5, 2.5, 2.5, 3.5))
+        self.assertTrue(self.plot._get_reset_enabled())
 
         # More than 1 data point
         self.analysis_model.add_evaluation_step((3, 4))

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -173,3 +173,23 @@ class TestPlot(unittest.TestCase):
 
         self.analysis_model.selected_step_index = None
         self.assertEqual(plot_metadata['selections'], [])
+
+    def test_resize_plot(self):
+
+        # No data
+        result = self.plot.resize_plot()
+        self.assertIsNone(result)
+        self.assertFalse(self.plot._get_reset_enabled())
+
+        # One data point
+        self.analysis_model.value_names = ('x', 'y')
+        self.analysis_model.add_evaluation_step((2, 3))
+        result = self.plot.resize_plot()
+        self.assertIsNone(result)
+        self.assertFalse(self.plot._get_reset_enabled())
+
+        # More than 1 data point
+        self.analysis_model.add_evaluation_step((3, 4))
+        result = self.plot.resize_plot()
+        self.assertEqual(result, (1.9, 3.1, 2.9, 4.1))
+        self.assertTrue(self.plot._get_reset_enabled())


### PR DESCRIPTION
Addresses #184, #185 & #186. While the plot did seem to get resized automatically, it sets the plot boundary to be exactly on an outlying plot point. This adds a little space around these edge values (10% of the plot height/width) and provides a button to reset the plot view. 
This also resets the plot view when there are no data value names available (and therefore no data to plot), for example after the analysis model has been cleared.