### PR TITLE
Hide ui notification

### DIFF
--- a/force_wfmanager/left_side_pane/tests/test_workflow_tree.py
+++ b/force_wfmanager/left_side_pane/tests/test_workflow_tree.py
@@ -43,6 +43,7 @@ def mock_new_modal(model_type, factory=None):
 
     return _mock_new_modal
 
+
 def mock_notification_listener_factory():
     mock_factory = mock.Mock(spec=BaseNotificationListenerFactory)
     mock_factory.ui_visible = True
@@ -137,7 +138,7 @@ class TestWorkflowTree(unittest.TestCase):
         with mock.patch(NEW_ENTITY_MODAL_PATH) as mock_modal:
             mock_factory = mock_notification_listener_factory()
             mock_modal.side_effect = mock_new_modal(
-                BaseNotificationListenerModel,factory=mock_factory
+                BaseNotificationListenerModel, factory=mock_factory
             )
             mock_ui_info = mock.Mock()
             mock_object = mock.Mock()

--- a/force_wfmanager/left_side_pane/tests/test_workflow_tree.py
+++ b/force_wfmanager/left_side_pane/tests/test_workflow_tree.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from unittest import mock
 
-from force_bdss.core.workflow import Workflow
+from force_bdss.api import Workflow, BaseNotificationListenerFactory
 
 from force_wfmanager.left_side_pane.workflow_tree import (
     WorkflowTree,
@@ -31,17 +31,22 @@ MODEL_EDIT_PATH = (
 )
 
 
-def mock_new_modal(model_type):
+def mock_new_modal(model_type, factory=None):
     def _mock_new_modal(*args, **kwargs):
         modal = mock.Mock(spec=NewEntityModal)
         modal.edit_traits = lambda: None
 
         # Any type is ok as long as it passes trait validation.
         # We choose BaseDataSourceModel.
-        modal.current_model = model_type(factory=None)
+        modal.current_model = model_type(factory=factory)
         return modal
 
     return _mock_new_modal
+
+def mock_notification_listener_factory():
+    mock_factory = mock.Mock(spec=BaseNotificationListenerFactory)
+    mock_factory.ui_visible = True
+    return mock_factory
 
 
 def mock_model_edit_dialog():
@@ -130,8 +135,9 @@ class TestWorkflowTree(unittest.TestCase):
 
     def test_new_notification_listener(self):
         with mock.patch(NEW_ENTITY_MODAL_PATH) as mock_modal:
+            mock_factory = mock_notification_listener_factory()
             mock_modal.side_effect = mock_new_modal(
-                BaseNotificationListenerModel
+                BaseNotificationListenerModel,factory=mock_factory
             )
             mock_ui_info = mock.Mock()
             mock_object = mock.Mock()

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -61,11 +61,11 @@ class WorkflowModelView(ModelView):
         self.model.execution_layers.remove(layer)
 
     def add_notification_listener(self, notification_listener):
-        """Adds a new empty execution layer"""
+        """Adds a new notification listener"""
         self.model.notification_listeners.append(notification_listener)
 
     def remove_notification_listener(self, notification_listener):
-        """Removes the execution layer from the model."""
+        """Removes the notification listener from the model."""
         self.model.notification_listeners.remove(notification_listener)
 
     def remove_data_source(self, data_source):
@@ -101,11 +101,14 @@ class WorkflowModelView(ModelView):
 
     @on_trait_change("model.notification_listeners[]")
     def update_notification_listeners_mv(self):
+        """Updates the modelviews for the notification listeners, but ignoring
+        any which are non UI visible"""
         self.notification_listeners_mv = [
             NotificationListenerModelView(
                 model=notification_listener,
             )
             for notification_listener in self.model.notification_listeners
+            if notification_listener.factory.ui_visible is True
         ]
 
     def _model_default(self):


### PR DESCRIPTION
Addresses https://github.com/force-h2020/force-wfmanager/issues/187. The change in the pr makes it so we now only create a modelview for models whose factory has ui_visible set to True. This is the default case in base_notification_listener_factory.