### PR TITLE
Title bar close bugfix

### DIFF
--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -12,3 +12,15 @@ class WfManager(TasksApplication):
             active_task='force_wfmanager.wfmanager_task',
             size=(800, 600)
         )]
+
+    def delete_tasks(self):
+        for window in self.windows:
+            tasks = window.tasks
+            for task in tasks:
+                window.remove_task(task)
+
+    def _application_exiting_fired(self):
+        """An event fired immediately before the GUI event loop is ended.
+        Is fired for both the menu-bar exit / Cmd-Q and clicking the title
+        bar exit button"""
+        self.delete_tasks()


### PR DESCRIPTION
Prevents raising exceptions on closing by removing the tasks from the window prior to closedown. This is the same workaround as for the menu bar closedown, except it requires implementing something for the application_exiting event in TasksApplication.

Not really sure how to write a test for this as it requires a window with tasks within the test environment!