### PR TITLE
Use Plugin Names

### DIFF
--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 
 from traits.api import (HasStrictTraits, Instance, List, Either,
                         on_trait_change, Dict, Str, Property, HTML, Bool,
@@ -157,11 +156,11 @@ class NewEntityModal(HasStrictTraits):
 
         # Order the dictionary alphabetically by plugin name
 
-        plugin_dict = OrderedDict(sorted(plugin_dict.items(),
-                                         key=lambda p: p[0].name))
+        ordered_keys = sorted(plugin_dict.keys(), key=lambda p: p.name)
 
         plugins = []
-        for plugin, factories in plugin_dict.items():
+        for plugin in ordered_keys:
+            factories = plugin_dict[plugin]
             plugins.append(PluginModelView(plugin=plugin,
                                            factories=factories,
                                            name=plugin.name))

--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from traits.api import (HasStrictTraits, Instance, List, Either,
                         on_trait_change, Dict, Str, Property, HTML, Bool,
                         ReadOnly)
@@ -153,11 +155,16 @@ class NewEntityModal(HasStrictTraits):
                 plugin_dict[plugin_from_factory] = []
             plugin_dict[plugin_from_factory].append(factory)
 
+        # Order the dictionary alphabetically by plugin name
+
+        plugin_dict = OrderedDict(sorted(plugin_dict.items(),
+                                         key=lambda p: p[0].name))
+
         plugins = []
-        for plugin, factories in zip(plugin_dict, plugin_dict.values()):
+        for plugin, factories in plugin_dict.items():
             plugins.append(PluginModelView(plugin=plugin,
                                            factories=factories,
-                                           name=plugin.id))
+                                           name=plugin.name))
         return Root(plugins=plugins)
 
     def _no_config_options_msg_default(self):
@@ -228,7 +235,7 @@ class NewEntityModal(HasStrictTraits):
                 name_desc_pairs.append([trait_name, trait_desc])
             else:
                 name_desc_pairs.append([trait_name,
-                                        'No Description Available'])
+                                        'No description available.'])
 
         # Format names as in the Instance Editor
         name_desc_pairs = [[name.replace('_', ' ').capitalize(), desc]

--- a/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
@@ -1,9 +1,5 @@
 import unittest
-import testfixtures
-from force_bdss.base_extension_plugin import BaseExtensionPlugin
-from force_bdss.core.base_factory import BaseFactory
 
-from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from traits.api import HasTraits, Instance
 
 from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
@@ -30,21 +26,6 @@ class ModalInfoDummy(HasTraits):
     def _ui_default(self):
         return UIDummy()
 
-class Plugin1(BaseExtensionPlugin):
-    def get_name(self):
-        return "Plugin1"
-
-    def get_description(self):
-        return "Plugin1 description"
-
-    def get_version(self):
-        return 0
-
-    def get_factory_classes(self):
-        return []
-
-
-
 
 class TestNewEntityModal(unittest.TestCase):
     def setUp(self):
@@ -57,12 +38,10 @@ class TestNewEntityModal(unittest.TestCase):
         self.handler = ModalHandler()
 
     def _get_dialog(self):
-        with testfixtures.LogCapture():
-            modal = NewEntityModal(
-                factories=self.mcos
-            )
+        modal = NewEntityModal(
+            factories=self.mcos
+        )
         return modal, ModalInfoDummy(object=modal)
-
 
     def test_add_entity(self):
         modal, modal_info = self._get_dialog()
@@ -128,36 +107,3 @@ class TestNewEntityModal(unittest.TestCase):
 
         self.assertIn("edit_traits_call_count", model_info(
             modal.current_model))
-
-    def test_tree_order(self):
-
-        factory = BaseFactory(plugin=Plugin1())
-
-
-
-
-
-class TestNewEntityModalGUI(GuiTestAssistant, unittest.TestCase):
-
-    def _get_dialog(self):
-        with testfixtures.LogCapture():
-            modal = NewEntityModal(
-                factories=[self.mcos]
-            )
-        return modal, ModalInfoDummy(object=modal)
-
-    def test_show(self):
-
-        self.plugin = ProbeExtensionPlugin()
-        self.mcos = [ProbeMCOFactory(self.plugin)]
-        self.workflow_mv = WorkflowModelView()
-
-        self.handler = ModalHandler()
-
-        modal, modal_info = self._get_dialog()
-
-        with self.event_loop():
-            ui = modal.edit_traits()
-
-        with self.delete_widget(ui.control):
-            ui.dispose()

--- a/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
@@ -107,3 +107,11 @@ class TestNewEntityModal(unittest.TestCase):
 
         self.assertIn("edit_traits_call_count", model_info(
             modal.current_model))
+
+    def test_plugins_root_default(self):
+
+        modal, modal_info = self._get_dialog()
+        root = modal._plugins_root_default()
+
+        self.assertEqual(len(root.plugins), 1)
+        self.assertEqual(root.plugins[0].plugin, self.plugin)

--- a/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
@@ -1,5 +1,9 @@
 import unittest
+import testfixtures
+from force_bdss.base_extension_plugin import BaseExtensionPlugin
+from force_bdss.core.base_factory import BaseFactory
 
+from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from traits.api import HasTraits, Instance
 
 from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
@@ -26,6 +30,21 @@ class ModalInfoDummy(HasTraits):
     def _ui_default(self):
         return UIDummy()
 
+class Plugin1(BaseExtensionPlugin):
+    def get_name(self):
+        return "Plugin1"
+
+    def get_description(self):
+        return "Plugin1 description"
+
+    def get_version(self):
+        return 0
+
+    def get_factory_classes(self):
+        return []
+
+
+
 
 class TestNewEntityModal(unittest.TestCase):
     def setUp(self):
@@ -38,10 +57,12 @@ class TestNewEntityModal(unittest.TestCase):
         self.handler = ModalHandler()
 
     def _get_dialog(self):
-        modal = NewEntityModal(
-            factories=self.mcos
-        )
+        with testfixtures.LogCapture():
+            modal = NewEntityModal(
+                factories=self.mcos
+            )
         return modal, ModalInfoDummy(object=modal)
+
 
     def test_add_entity(self):
         modal, modal_info = self._get_dialog()
@@ -107,3 +128,36 @@ class TestNewEntityModal(unittest.TestCase):
 
         self.assertIn("edit_traits_call_count", model_info(
             modal.current_model))
+
+    def test_tree_order(self):
+
+        factory = BaseFactory(plugin=Plugin1())
+
+
+
+
+
+class TestNewEntityModalGUI(GuiTestAssistant, unittest.TestCase):
+
+    def _get_dialog(self):
+        with testfixtures.LogCapture():
+            modal = NewEntityModal(
+                factories=[self.mcos]
+            )
+        return modal, ModalInfoDummy(object=modal)
+
+    def test_show(self):
+
+        self.plugin = ProbeExtensionPlugin()
+        self.mcos = [ProbeMCOFactory(self.plugin)]
+        self.workflow_mv = WorkflowModelView()
+
+        self.handler = ModalHandler()
+
+        modal, modal_info = self._get_dialog()
+
+        with self.event_loop():
+            ui = modal.edit_traits()
+
+        with self.delete_widget(ui.control):
+            ui.dispose()

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -576,6 +576,6 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
 
         plugins = [ProbeExtensionPlugin(), ProbeExtensionPlugin()]
         self.wfmanager_task.window.application.plugin_manager = plugins
-        
+
         with self.event_loop():
             self.wfmanager_task.open_plugins()

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -15,7 +15,7 @@ from pyface.api import FileDialog, OK, ConfirmationDialog, YES, NO, CANCEL
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 
 from force_bdss.tests.probe_classes.factory_registry_plugin import \
-    ProbeFactoryRegistryPlugin
+    ProbeFactoryRegistryPlugin, ProbeExtensionPlugin
 from force_bdss.api import (MCOStartEvent, MCOProgressEvent, Workflow,
                             WorkflowWriter, WorkflowReader,
                             InvalidFileException)
@@ -573,5 +573,9 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
             self.wfmanager_task.initialized()
 
     def test_open_plugin_dialog(self):
+
+        plugins = [ProbeExtensionPlugin(), ProbeExtensionPlugin()]
+        self.wfmanager_task.window.application.plugin_manager = plugins
+        
         with self.event_loop():
             self.wfmanager_task.open_plugins()

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -262,6 +262,10 @@ class WfManagerTask(Task):
         plugins = [plugin
                    for plugin in self.window.application.plugin_manager
                    if isinstance(plugin, BaseExtensionPlugin)]
+
+        # Plugins guaranteed to have an id, so sort by that if name is not set
+        plugins.sort(key=lambda s: s.name if s.name not in ('', None)
+                     else s.id)
         dlg = PluginDialog(plugins)
         dlg.edit_traits()
 


### PR DESCRIPTION
Fixes #218 #216. Uses the actual names for plugins instead of id, though still uses id if a plugin does not have a name assigned. Plugins listed in alphabetical order.