### PR TITLE
Refactor new_modal_dialog

### DIFF
--- a/force_wfmanager/left_side_pane/new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/new_entity_modal.py
@@ -9,11 +9,8 @@ from traitsui.api import (View, Handler, HSplit, Group, VGroup, UItem,
 
 from envisage.plugin import Plugin
 
-from force_bdss.api import (
-    BaseFactory, BaseMCOModel, BaseMCOFactory,
-    BaseDataSourceModel, BaseDataSourceFactory,
-    BaseMCOParameter, BaseMCOParameterFactory,
-    BaseNotificationListenerModel, BaseNotificationListenerFactory)
+from force_bdss.api import (BaseFactory, BaseMCOModel, BaseDataSourceModel,
+                            BaseMCOParameter, BaseNotificationListenerModel)
 
 from force_wfmanager.left_side_pane.view_utils import model_info
 
@@ -197,6 +194,7 @@ class NewEntityModal(HasStrictTraits):
         one item exists for this model and 2. That those items
         are actually visible to the user"""
         return model_info(self.current_model) != []
+
     def _get_model_description_HTML(self):
         """Format a description of the currently selected model and it's
         parameters, using desc metadata from the traits in
@@ -272,13 +270,14 @@ def htmlformat(factory_title=None, factory_description=None,
         body = []
 
     if factory_description is not None:
-        body.append("<p>{description}</p>".format(description=
-                                                  factory_description))
+        body.append("<p>{description}</p>".format(
+            description=factory_description)
+        )
     if parameter_info is not None:
         for name, description in parameter_info:
-            parameter_html = titled_paragraph.format(name=name,
-                                                     description=description)
+            parameter_html = titled_paragraph.format(
+                name=name, description=description
+            )
             body.append(parameter_html)
 
     return html.format(body="".join(body))
-

--- a/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
@@ -6,7 +6,7 @@ from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
 from force_bdss.tests.probe_classes.data_source import ProbeDataSourceFactory
 from force_bdss.tests.probe_classes.probe_extension_plugin import \
     ProbeExtensionPlugin
-from force_bdss.tests.dummy_classes.data_source import DummyDataSource, DummyDataSourceFactory, DummyDataSourceModel
+from force_bdss.tests.dummy_classes.data_source import DummyDataSourceModel
 
 from force_wfmanager.left_side_pane.new_entity_modal import (
     ModalHandler, NewEntityModal, htmlformat)

--- a/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
@@ -6,9 +6,10 @@ from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
 from force_bdss.tests.probe_classes.data_source import ProbeDataSourceFactory
 from force_bdss.tests.probe_classes.probe_extension_plugin import \
     ProbeExtensionPlugin
+from force_bdss.tests.dummy_classes.data_source import DummyDataSource, DummyDataSourceFactory, DummyDataSourceModel
 
 from force_wfmanager.left_side_pane.new_entity_modal import (
-    ModalHandler, NewEntityModal)
+    ModalHandler, NewEntityModal, htmlformat)
 from force_wfmanager.left_side_pane.workflow_tree import WorkflowModelView
 from force_wfmanager.left_side_pane.view_utils import model_info
 
@@ -85,7 +86,7 @@ class TestNewEntityModal(unittest.TestCase):
 
         self.assertEqual(id(first_model), id(modal.current_model))
 
-    def test_description(self):
+    def test_description_mco_modal(self):
 
         modal, modal_info = self._get_dialog()
 
@@ -115,3 +116,23 @@ class TestNewEntityModal(unittest.TestCase):
 
         self.assertEqual(len(root.plugins), 1)
         self.assertEqual(root.plugins[0].plugin, self.plugin)
+
+    def _get_dialog_data(self):
+        modal = NewEntityModal(
+            factories=self.data_sources
+        )
+        return modal, ModalInfoDummy(object=modal)
+
+    def test_description_non_editable_datasource(self):
+
+        modal, modal_info = self._get_dialog_data()
+        modal.selected_factory = self.data_sources[0]
+        # An empty DataSourceModel with no editable traits
+        modal.current_model = DummyDataSourceModel(self.data_sources[0])
+        self.assertFalse(modal.current_model_editable)
+        self.assertIn("No description available", modal.model_description_HTML)
+
+    def test_htmlformat(self):
+
+        self.assertNotIn('<h1>', htmlformat(None))
+        self.assertIn('<p>test</p>', htmlformat(body='<p>test</p>'))

--- a/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
+++ b/force_wfmanager/left_side_pane/tests/test_new_entity_modal.py
@@ -27,7 +27,8 @@ class ModalInfoDummy(HasTraits):
     def _ui_default(self):
         return UIDummy()
 
-class DataSourceModelDesc(BaseDataSourceModel):
+
+class DataSourceModelDescription(BaseDataSourceModel):
 
     test_trait = Int(13, desc='Test trait')
 
@@ -130,7 +131,8 @@ class TestNewEntityModal(unittest.TestCase):
     def test_description_editable_data_source(self):
         modal, modal_info = self._get_dialog_data()
         modal.selected_factory = modal.factories[0]
-        modal.current_model = DataSourceModelDesc(modal.selected_factory)
+        modal.current_model = DataSourceModelDescription(
+            modal.selected_factory)
 
         self.assertIn("Test trait",
                       modal.model_description_HTML)


### PR DESCRIPTION
A few small changes: Added Unicode, consistently used " over ' for strings, more sensible variable names and HTML strings are now created using a function rather than using .format within a function.