### PR TITLE
Reverted task deletion prior to application shutdown

### DIFF
--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -12,15 +12,3 @@ class WfManager(TasksApplication):
             active_task='force_wfmanager.wfmanager_task',
             size=(800, 600)
         )]
-
-    def delete_tasks(self):
-        for window in self.windows:
-            tasks = window.tasks
-            for task in tasks:
-                window.remove_task(task)
-
-    def _application_exiting_fired(self):
-        """An event fired immediately before the GUI event loop is ended.
-        Is fired for both the menu-bar exit / Cmd-Q and clicking the title
-        bar exit button"""
-        self.delete_tasks()

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -416,10 +416,6 @@ class WfManagerTask(Task):
             return
 
         app = self.window.application
-        window = self.window
-
-        window.remove_task(self)
-        window.close()
         app.exit()
 
     # Default initializers


### PR DESCRIPTION
This isn't really a fix since technically the application was performing as intended! But what was happening: As a fix for the Exceptions raised on closing, tasks were being deleted immediately before exit (via _application_exiting_fired). However the save_state method in TasksApplication is called _after_ this, so it was saving a taskless window, which would then be reloaded on startup.
We'll have to find another way to fix the exceptions on closing it seems!