### PR TITLE
Close Exceptions MkII

### DIFF
--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -13,12 +13,14 @@ class WfManager(TasksApplication):
             size=(800, 600)
         )]
 
+    # FIXME: This isn't needed if the bug in traitsui/qt4/ui_panel.py is fixed
     def _prepare_exit(self):
         """Same functionality as TasksApplication._prepare_exit(), but
         _save_state is called before application_exiting is fired"""
         self._save_state()
         self.application_exiting = self
 
+    # FIXME: This isn't needed if the bug in traitsui/qt4/ui_panel.py is fixed
     def _application_exiting_fired(self):
         for window in self.windows:
             tasks = window.tasks

--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -12,3 +12,15 @@ class WfManager(TasksApplication):
             active_task='force_wfmanager.wfmanager_task',
             size=(800, 600)
         )]
+
+    def _prepare_exit(self):
+        """Same functionality as TasksApplication._prepare_exit(), but
+        _save_state is called before application_exiting is fired"""
+        self._save_state()
+        self.application_exiting = self
+
+    def _application_exiting_fired(self):
+        for window in self.windows:
+            tasks = window.tasks
+            for task in tasks:
+                window.remove_task(task)

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -416,10 +416,6 @@ class WfManagerTask(Task):
             return
 
         app = self.window.application
-        window = self.window
-
-        window.remove_task(self)
-        window.close()
         app.exit()
 
     # Default initializers


### PR DESCRIPTION
The previous fix #226 was causing the tasks to be deleted in _application_exiting_fired, before saving the application state. This happens in tasks_application.py:

def _prepare_exit(self):
     """ Called immediately before the extant windows are destroyed and the GUI event loop is terminated."""
    self.application_exiting = self
    self._save_state()

The fix is just to override _prepare_exit in wfmanager.py and switch the order of these two calls. The application_exiting event does not appear to be used anywhere else (searching the files in site-packages for "application_exiting" gives no results)