### PR TITLE
Debug Logging Option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Release 0.3.0
 -------------
 
+- Added debug logging option
+
 Release 0.2.0
 -------------
 

--- a/force_wfmanager/gui/run.py
+++ b/force_wfmanager/gui/run.py
@@ -7,13 +7,12 @@ from envisage.ui.tasks.tasks_plugin import TasksPlugin
 from stevedore import extension
 from stevedore.exception import NoMatches
 
+from traits.api import push_exception_handler
+
 from force_bdss.api import FactoryRegistryPlugin
 
 from force_wfmanager.wfmanager import WfManager
 from force_wfmanager.wfmanager_plugin import WfManagerPlugin
-
-from traits.api import push_exception_handler
-
 from force_wfmanager.version import __version__
 
 push_exception_handler(lambda *args: None, reraise_exceptions=True)
@@ -21,17 +20,24 @@ push_exception_handler(lambda *args: None, reraise_exceptions=True)
 
 @click.command()
 @click.version_option(version=__version__)
+@click.option('--debug', is_flag=True, default=False,
+              help="Prints extra debug information in force_wfmanager.log")
 @click.argument('workflow_file', type=click.Path(exists=True), required=False,
                 default=None,)
-def force_wfmanager(workflow_file):
+def force_wfmanager(workflow_file, debug):
     """Launches the FORCE workflow manager application"""
-    main(workflow_file=workflow_file)
+    main(workflow_file=workflow_file, debug=debug)
 
 
-def main(workflow_file=None):
+def main(workflow_file=None, debug=False):
     """Launches the FORCE workflow manager application"""
-    logging.basicConfig(filename="force_wfmanager.log", filemode="w")
+    if debug is False:
+        logging.basicConfig(filename="force_wfmanager.log", filemode="w")
+    else:
+        logging.basicConfig(filename="force_wfmanager.log", filemode="w",
+                            level=logging.DEBUG)
     log = logging.getLogger(__name__)
+
     plugins = [CorePlugin(), TasksPlugin(), FactoryRegistryPlugin(),
                WfManagerPlugin(workflow_file=workflow_file)]
 

--- a/force_wfmanager/gui/tests/test_click_run.py
+++ b/force_wfmanager/gui/tests/test_click_run.py
@@ -44,3 +44,5 @@ class TestClickRun(unittest.TestCase):
         with mock.patch('force_wfmanager.gui.run.WfManager') as mock_wf:
             mock_wf.return_value = MockWfManager()
             force_wfmanager.gui.run.main(debug=True)
+            self.log = force_wfmanager.gui.run.logging.getLogger(__name__)
+            self.assertEqual(self.log.getEffectiveLevel(), 10)

--- a/force_wfmanager/gui/tests/test_click_run.py
+++ b/force_wfmanager/gui/tests/test_click_run.py
@@ -14,6 +14,14 @@ def mock_run_constructor(*args, **kwargs):
     mock_wf_run = mock.Mock(spec=force_wfmanager.gui.run)
     mock_wf_run.main = lambda: None
 
+class MockWfManager(object):
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run(self):
+        pass
+
 
 class TestClickRun(unittest.TestCase):
 
@@ -30,3 +38,8 @@ class TestClickRun(unittest.TestCase):
             force_wfmanager.gui.run.force_wfmanager()
 
             mock_run.force_wfmanager.assert_called()
+
+    def test_run_with_debug(self):
+        with mock.patch('force_wfmanager.gui.run.WfManager') as mock_wf:
+            mock_wf.return_value = MockWfManager()
+            force_wfmanager.gui.run.main(debug=True)

--- a/force_wfmanager/gui/tests/test_click_run.py
+++ b/force_wfmanager/gui/tests/test_click_run.py
@@ -14,6 +14,7 @@ def mock_run_constructor(*args, **kwargs):
     mock_wf_run = mock.Mock(spec=force_wfmanager.gui.run)
     mock_wf_run.main = lambda: None
 
+
 class MockWfManager(object):
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Adds a cmd line option --debug which adds debug logs to force_wfmanager.log.

The only test is a run with debug=True passed to main. I'm not even sure if it should have this, since the logger is a system-wide thing, so any subsequent tests will also have debug logs written to force_wfmanager.log.

This doesn't cause any problems at the minute, but does mean the tests aren't totally self-contained. 