### PR TITLE
Remove HTML from main window

### DIFF
--- a/force_wfmanager/left_side_pane/data_source_model_view.py
+++ b/force_wfmanager/left_side_pane/data_source_model_view.py
@@ -174,36 +174,6 @@ class DataSourceModelView(ModelView):
         super(DataSourceModelView, self).__init__(*args, **kwargs)
 
         self._create_slots_tables()
-        # TODO: Make this set up the traits view, based on how many slots the
-        # datasource has
-        # self.setup_traits_view()
-
-    # def _traits_view_default(self):
-    #
-    #     view = View(
-    #         VGroup(
-    #             Item(
-    #                 "input_slots_representation",
-    #                 label="Input variables",
-    #                 editor=input_slots_editor,
-    #                 height=200
-    #             ),
-    #             Item(
-    #                 "output_slots_representation",
-    #                 label="Output variables",
-    #                 editor=output_slots_editor,
-    #                 height=100
-    #             ),
-    #             Item(
-    #                 "selected_slot_description",
-    #                 label="Description",
-    #                 editor=HTMLEditor(),
-    #                 height=100
-    #                 )
-    #         ),
-    #         kind="subpanel",
-    #     )
-    #     return view
 
     @on_trait_change('input_slots_representation.name,'
                      'output_slots_representation.name')

--- a/force_wfmanager/left_side_pane/data_source_model_view.py
+++ b/force_wfmanager/left_side_pane/data_source_model_view.py
@@ -148,13 +148,11 @@ class DataSourceModelView(ModelView):
                     "input_slots_representation",
                     label="Input variables",
                     editor=input_slots_editor,
-                    height=900
                 ),
                 Item(
                     "output_slots_representation",
                     label="Output variables",
                     editor=output_slots_editor,
-                    height=100
                 )
             ),
             VGroup(

--- a/force_wfmanager/left_side_pane/workflow_tree.py
+++ b/force_wfmanager/left_side_pane/workflow_tree.py
@@ -243,19 +243,25 @@ class WorkflowTree(ModelView):
     verify_workflow_event = Event
 
     traits_view = View(
-        VGroup(
-            UItem(name='workflow_mv',
-                  editor=tree_editor,
-                  show_label=False
-                  ),
-            UReadonly(
-                name='selected_error',
-                editor=TextEditor(),
+        Group(
+            VGroup(
+                UItem(name='workflow_mv',
+                      editor=tree_editor,
+                      show_label=False
+                      ),
+                ),
+            VGroup(
+                UReadonly(
+                    name='selected_error',
+                    editor=TextEditor(),
+                    ),
+                label='Workflow Errors',
+                show_border=True
                 ),
             ),
         width=800,
         height=600,
-        resizable=True
+        resizable=True,
         )
 
     def __init__(self, model, factory_registry, *args, **kwargs):


### PR DESCRIPTION
Fixes #217. Due to resizing issues with HTMLEditor, it may be easier to use the basic HTML parsing offered by TextEditor. This only needs to be done for regions where there is not enough space for all the Items to be displayed at their full extent.

