### PR TITLE
Exit method moved to TaskWindow subclass

### DIFF
--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -1,12 +1,15 @@
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+import unittest.mock as mock
 
+from envisage.core_plugin import CorePlugin
+from envisage.ui.tasks.tasks_plugin import TasksPlugin
+
+from pyface.api import (ConfirmationDialog, YES, NO, CANCEL)
+
+from force_wfmanager.wfmanager_plugin import WfManagerPlugin
 from force_wfmanager.wfmanager import WfManager, TaskWindowClosePrompt
 from force_wfmanager.wfmanager_task import WfManagerTask
-from pyface.api import (ConfirmationDialog, YES, NO, CANCEL)
+
 
 CONFIRMATION_DIALOG_PATH = 'force_wfmanager.wfmanager.ConfirmationDialog'
 
@@ -20,11 +23,26 @@ def mock_dialog(dialog_class, result, path=''):
     return mock_dialog_call
 
 
+def dummy_wfmanager():
+
+    plugins = [CorePlugin(), TasksPlugin(), WfManagerPlugin()]
+    wfmanager = WfManager(plugins=plugins)
+    wfmanager.run = wfmanager._create_windows
+    return wfmanager
+
+
 class TestWfManager(unittest.TestCase):
 
     def test_wfmanager(self):
         wfmanager = WfManager()
         self.assertEqual(len(wfmanager.default_layout), 1)
+
+    def test_remove_tasks_on_application_exiting(self):
+        mock_wfmanager = dummy_wfmanager()
+        mock_wfmanager.run()
+        self.assertEqual(len(mock_wfmanager.windows[0].tasks), 1)
+        mock_wfmanager.application_exiting = True
+        self.assertEqual(len(mock_wfmanager.windows[0].tasks), 0)
 
 
 class TestTaskWindowClosePrompt(unittest.TestCase):

--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -1,9 +1,74 @@
 import unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
-from force_wfmanager.wfmanager import WfManager
+from force_wfmanager.wfmanager import WfManager, TaskWindowClosePrompt
+from force_wfmanager.wfmanager_task import WfManagerTask
+from pyface.api import (ConfirmationDialog, YES, NO, CANCEL)
+
+CONFIRMATION_DIALOG_PATH = 'force_wfmanager.wfmanager.ConfirmationDialog'
+
+
+def mock_dialog(dialog_class, result, path=''):
+    def mock_dialog_call(*args, **kwargs):
+        dialog = mock.Mock(spec=dialog_class)
+        dialog.open = lambda: result
+        dialog.path = path
+        return dialog
+    return mock_dialog_call
 
 
 class TestWfManager(unittest.TestCase):
+
     def test_wfmanager(self):
         wfmanager = WfManager()
         self.assertEqual(len(wfmanager.default_layout), 1)
+
+
+class TestTaskWindowClosePrompt(unittest.TestCase):
+
+    def test_exit_application_with_saving(self):
+        wfmanager_task = WfManagerTask()
+        wfmanager_task.save_workflow = mock.Mock(return_value=True)
+        window = TaskWindowClosePrompt(tasks=[wfmanager_task])
+        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog:
+            mock_confirm_dialog.side_effect = mock_dialog(
+                ConfirmationDialog, YES)
+            close_result = window.close()
+            self.assertTrue(wfmanager_task.save_workflow.called)
+            self.assertTrue(close_result)
+
+    def test_exit_application_with_saving_failure(self):
+        wfmanager_task = WfManagerTask()
+        wfmanager_task.save_workflow = mock.Mock(return_value=False)
+        window = TaskWindowClosePrompt(tasks=[wfmanager_task])
+        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog:
+            mock_confirm_dialog.side_effect = mock_dialog(
+                ConfirmationDialog, YES)
+            close_result = window.close()
+            self.assertTrue(wfmanager_task.save_workflow.called)
+            self.assertFalse(close_result)
+
+    def test_exit_application_without_saving(self):
+        wfmanager_task = WfManagerTask()
+        wfmanager_task.save_workflow = mock.Mock(return_value=True)
+        window = TaskWindowClosePrompt(tasks=[wfmanager_task])
+        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog:
+            mock_confirm_dialog.side_effect = mock_dialog(
+                ConfirmationDialog, NO)
+            close_result = window.close()
+            self.assertFalse(wfmanager_task.save_workflow.called)
+            self.assertTrue(close_result)
+
+    def test_cancel_exit_application(self):
+        wfmanager_task = WfManagerTask()
+        wfmanager_task.save_workflow = mock.Mock(return_value=True)
+        window = TaskWindowClosePrompt(tasks=[wfmanager_task])
+        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog:
+            mock_confirm_dialog.side_effect = mock_dialog(
+                ConfirmationDialog, CANCEL)
+            close_result = window.close()
+            self.assertFalse(wfmanager_task.save_workflow.called)
+            self.assertFalse(close_result)

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -11,7 +11,7 @@ import subprocess
 from envisage.api import Application
 
 from pyface.tasks.api import TaskLayout, TaskWindow
-from pyface.api import FileDialog, OK, ConfirmationDialog, YES, NO, CANCEL
+from pyface.api import FileDialog, OK, YES, CANCEL
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 
 from force_bdss.tests.probe_classes.factory_registry_plugin import \
@@ -28,7 +28,7 @@ from force_wfmanager.left_side_pane.side_pane import SidePane
 from force_wfmanager.left_side_pane.workflow_tree import WorkflowTree
 
 FILE_DIALOG_PATH = 'force_wfmanager.wfmanager_task.FileDialog'
-CONFIRMATION_DIALOG_PATH = 'force_wfmanager.wfmanager_task.ConfirmationDialog'
+CONFIRMATION_DIALOG_PATH = 'force_wfmanager.wfmanager.ConfirmationDialog'
 INFORMATION_PATH = 'force_wfmanager.wfmanager_task.information'
 CONFIRM_PATH = 'force_wfmanager.wfmanager_task.confirm'
 FILE_OPEN_PATH = 'force_wfmanager.wfmanager_task.open'
@@ -450,84 +450,10 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
                 mock_error.call_args[0][1],
                 'Unable to run BDSS: write failed')
 
-    def test_exit_application_with_saving(self):
-        mock_open = mock.mock_open()
-        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog, \
-                mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
-                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
-                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
-            mock_confirm_dialog.side_effect = mock_dialog(
-                ConfirmationDialog, YES)
-            mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
-            mock_writer.side_effect = mock_file_writer
+    def test_exit(self):
 
-            self.wfmanager_task.exit()
-
-            mock_confirm_dialog.assert_called()
-            mock_file_dialog.assert_called()
-            mock_open.assert_called()
-            mock_writer.assert_called()
-            self.wfmanager_task.window.application.exit.assert_called()
-
-    def test_exit_application_with_saving_failure(self):
-        mock_open = mock.mock_open()
-        mock_open.side_effect = Exception("OUPS")
-        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog, \
-                mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
-                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
-                mock.patch(ERROR_PATH) as mock_error, \
-                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
-            mock_confirm_dialog.side_effect = mock_dialog(
-                ConfirmationDialog, YES)
-            mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
-            mock_error.side_effect = mock_show_error
-            mock_writer.side_effect = mock_file_writer
-
-            self.wfmanager_task.exit()
-
-            mock_confirm_dialog.assert_called()
-            mock_file_dialog.assert_called()
-            mock_open.assert_called()
-            mock_writer.write.assert_not_called()
-            self.wfmanager_task.window.application.exit.assert_not_called()
-
-    def test_exit_application_without_saving(self):
-        mock_open = mock.mock_open()
-        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog, \
-                mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
-                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
-                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
-            mock_confirm_dialog.side_effect = mock_dialog(
-                ConfirmationDialog, NO)
-            mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
-            mock_writer.side_effect = mock_file_writer
-
-            self.wfmanager_task.exit()
-
-            mock_confirm_dialog.assert_called()
-            mock_file_dialog.assert_not_called()
-            mock_open.assert_not_called()
-            mock_writer.write.assert_not_called()
-            self.wfmanager_task.window.application.exit.assert_called()
-
-    def test_cancel_exit_application(self):
-        mock_open = mock.mock_open()
-        with mock.patch(CONFIRMATION_DIALOG_PATH) as mock_confirm_dialog, \
-                mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, \
-                mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
-                mock.patch(WORKFLOW_WRITER_PATH) as mock_writer:
-            mock_confirm_dialog.side_effect = mock_dialog(
-                ConfirmationDialog, CANCEL)
-            mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
-            mock_writer.side_effect = mock_file_writer
-
-            self.wfmanager_task.exit()
-
-            mock_confirm_dialog.assert_called()
-            mock_file_dialog.assert_not_called()
-            mock_open.assert_not_called()
-            mock_writer.write.assert_not_called()
-            self.wfmanager_task.window.application.exit.assert_not_called()
+        self.wfmanager_task.exit()
+        self.assertTrue(self.wfmanager_task.window.close.called)
 
     def test_dispatch_mco_event(self):
         send_event = self.wfmanager_task._server_event_callback

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -25,7 +25,6 @@ from force_wfmanager.left_side_pane.side_pane import SidePane
 from force_wfmanager.left_side_pane.workflow_tree import WorkflowTree
 
 FILE_DIALOG_PATH = 'force_wfmanager.wfmanager_task.FileDialog'
-CONFIRMATION_DIALOG_PATH = 'force_wfmanager.wfmanager.ConfirmationDialog'
 INFORMATION_PATH = 'force_wfmanager.wfmanager_task.information'
 CONFIRM_PATH = 'force_wfmanager.wfmanager_task.confirm'
 FILE_OPEN_PATH = 'force_wfmanager.wfmanager_task.open'

--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -28,6 +28,9 @@ class WfManager(TasksApplication):
 
     # FIXME: This isn't needed if the bug in traitsui/qt4/ui_panel.py is fixed
     def _application_exiting_fired(self):
+        self._remove_tasks()
+
+    def _remove_tasks(self):
         for window in self.windows:
             tasks = window.tasks
             for task in tasks:

--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -44,7 +44,7 @@ class TaskWindowClosePrompt(TaskWindow):
         fails, the application is not closed so he has a chance to try to
         save again. Overrides close from pyface.tasks.task_window """
 
-        # The attached wfmanager_task for save_methods
+        # The attached wfmanager_task for saving methods
         wfmanager_task = self.tasks[0]
 
         # Pop up for user input
@@ -61,9 +61,11 @@ class TaskWindowClosePrompt(TaskWindow):
         # Save
         if result is YES:
             save_result = wfmanager_task.save_workflow()
-            # On failed save, don't close the window
+
+            # On a failed save, don't close the window
             if not save_result:
                 return False
+
             close_result = super(TaskWindowClosePrompt, self).close()
             return close_result
 

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -9,8 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from traits.api import Instance, on_trait_change, File, Str, Bool, List
 
 from pyface.api import (
-    FileDialog, OK, error, ConfirmationDialog, YES, CANCEL, GUI, confirm,
-    information
+    FileDialog, OK, error, YES, GUI, confirm, information
 )
 
 from pyface.tasks.action.api import SMenu, SMenuBar, TaskAction
@@ -393,30 +392,10 @@ class WfManagerTask(Task):
             )
 
     def exit(self):
-        """ Exit the application. It first asks the user to save the current
-        Worklfow. The user can accept to save, ignore the request, or
-        cancel the quit. If the user wants to save, but the save fails, the
-        application is not closed so he has a chance to try to save again. """
-        dialog = ConfirmationDialog(
-            parent=None,
-            message='Do you want to save before exiting the Workflow '
-                    'Manager ?',
-            cancel=True,
-            yes_label='Save',
-            no_label='Don\'t save',
-        )
+        """ Exit the main window via TaskWindowClosePrompt's window.close(),
+        which opens a dialog with the option to save the current workflow."""
 
-        result = dialog.open()
-
-        if result is YES:
-            save_result = self.save_workflow()
-            if not save_result:
-                return
-        elif result is CANCEL:
-            return
-
-        app = self.window.application
-        app.exit()
+        self.window.close()
 
     # Default initializers
 


### PR DESCRIPTION
This creates a subclass of TaskWindow which has an exit prompt, which gives the user a chance to save before quitting. 
Putting this functionality in the TaskWindow's close() method means it will also be triggered on closing via title bar, not just those performed through the menu bar. 
It currently relies on the first task in window.tasks being the WfManagerTask, as well as the window being the only TaskWindow (so closing it means exiting the application).