### PR TITLE
Sync against change in MCOProgressEvent and design change in MCO

### DIFF
--- a/force_wfmanager/plugins/ui_notification/event_serializer.py
+++ b/force_wfmanager/plugins/ui_notification/event_serializer.py
@@ -1,5 +1,5 @@
 import json
-from force_bdss.api import BaseDriverEvent
+from force_bdss.api import BaseDriverEvent, pop_recursive
 
 
 class SerializerError(Exception):
@@ -18,7 +18,9 @@ class EventSerializer(object):
                                   "from BaseDriverEvent")
         data = json.dumps(
             {"type": event.__class__.__name__,
-             "model_data": event.__getstate__()
+             "model_data": pop_recursive(
+                 event.__getstate__(),
+                 "__traits_version__")
              }
         )
 

--- a/force_wfmanager/plugins/ui_notification/tests/test_event_serializer.py
+++ b/force_wfmanager/plugins/ui_notification/tests/test_event_serializer.py
@@ -9,8 +9,8 @@ from force_wfmanager.plugins.ui_notification.event_serializer import \
 class TestEventSerializer(unittest.TestCase):
     def test_serialize(self):
         event = MCOStartEvent(
-            input_names=("a", "b"),
-            output_names=("c", 'd')
+            parameter_names=["a", "b"],
+            kpi_names=["c", 'd']
         )
 
         data = EventSerializer().serialize(event)
@@ -20,9 +20,8 @@ class TestEventSerializer(unittest.TestCase):
             {
                 "type": "MCOStartEvent",
                 "model_data": {
-                    "__traits_version__": "4.6.0",
-                    "input_names": ["a", "b"],
-                    "output_names": ["c", "d"],
+                    "parameter_names": ["a", "b"],
+                    "kpi_names": ["c", "d"],
                 }
             }
         )

--- a/force_wfmanager/plugins/ui_notification/tests/test_ui_notification.py
+++ b/force_wfmanager/plugins/ui_notification/tests/test_ui_notification.py
@@ -2,7 +2,7 @@ import unittest
 from testfixtures import LogCapture
 
 from force_bdss.api import MCOStartEvent, MCOProgressEvent, \
-    MCOFinishEvent
+    MCOFinishEvent, DataValue
 from force_wfmanager.plugins.ui_notification.ui_notification import \
     UINotification
 from force_wfmanager.plugins.ui_notification.ui_notification_factory import \
@@ -53,7 +53,11 @@ class TestUINotification(unittest.TestCase):
             self.pub_socket.send_multipart.call_args[0][0][0:2],
             [x.encode('utf-8') for x in ['MESSAGE', 'an_id']])
 
-        listener.deliver(MCOProgressEvent(input=(1, 2, 3), output=(4, 5)))
+        listener.deliver(MCOProgressEvent(
+            optimal_point=[DataValue(value=1),
+                           DataValue(value=2),
+                           DataValue(value=3)],
+            optimal_kpis=[DataValue(value=4), DataValue(value=5)]))
         self.assertEqual(
             self.pub_socket.send_multipart.call_args[0][0][0:2],
             [x.encode('utf-8') for x in ['MESSAGE', 'an_id']])

--- a/force_wfmanager/plugins/ui_notification/ui_notification.py
+++ b/force_wfmanager/plugins/ui_notification/ui_notification.py
@@ -76,6 +76,7 @@ class UINotification(BaseNotificationListener):
             raise TypeError("Event is not a BaseDriverEvent")
 
         data = self._serializer.serialize(event)
+
         self._pub_socket.send_multipart(
             [x.encode('utf-8') for x in ["MESSAGE", self._identifier, data]])
 

--- a/force_wfmanager/server/event_deserializer.py
+++ b/force_wfmanager/server/event_deserializer.py
@@ -1,5 +1,7 @@
 import json
 
+from force_bdss.api import DataValue, MCOProgressEvent
+
 
 class DeserializerError(Exception):
     """Raised when the deserialization cannot be performed for any reason."""
@@ -58,4 +60,11 @@ class EventDeserializer(object):
             raise DeserializerError("Unable to find model data for "
                                     "type {}".format(class_name))
 
-        return cls(**d["model_data"])
+        model_data = d["model_data"]
+        if cls == MCOProgressEvent:
+            model_data["optimal_point"] = [
+                DataValue(**data) for data in model_data["optimal_point"]]
+            model_data["optimal_kpis"] = [
+                DataValue(**data) for data in model_data["optimal_kpis"]]
+
+        return cls(**model_data)

--- a/force_wfmanager/server/tests/test_event_deserializer.py
+++ b/force_wfmanager/server/tests/test_event_deserializer.py
@@ -5,7 +5,7 @@ import unittest
 from force_wfmanager.server.event_deserializer import (
     EventDeserializer, DeserializerError)
 
-from force_bdss.api import MCOStartEvent
+from force_bdss.api import MCOStartEvent, MCOProgressEvent
 
 
 class TestEventDeserializer(unittest.TestCase):
@@ -22,6 +22,39 @@ class TestEventDeserializer(unittest.TestCase):
         self.assertIsInstance(event, MCOStartEvent)
         self.assertEqual(event.parameter_names, event.parameter_names)
         self.assertEqual(event.kpi_names, event.kpi_names)
+
+    def test_progress_event_deserialize(self):
+        data = json.dumps({
+            "type": "MCOProgressEvent",
+            "model_data": {
+                "optimal_point": [
+                    {
+                        "value": 1.0
+                    },
+                    {
+                        "value": 2.0
+                    }
+                ],
+                "optimal_kpis": [
+                    {
+                        "value": 3.0
+                    },
+                ],
+                "weights": [1.0],
+            }
+        })
+
+        event = EventDeserializer().deserialize(data)
+        self.assertIsInstance(event, MCOProgressEvent)
+        self.assertEqual(len(event.optimal_point), 2)
+        self.assertEqual(event.optimal_point[0].value, 1.0)
+        self.assertEqual(event.optimal_point[1].value, 2.0)
+
+        self.assertEqual(len(event.optimal_kpis), 1)
+        self.assertEqual(event.optimal_kpis[0].value, 3.0)
+
+        self.assertEqual(event.weights, [1.0])
+
 
     def test_invalid_cases(self):
         invalid_cases = [

--- a/force_wfmanager/server/tests/test_event_deserializer.py
+++ b/force_wfmanager/server/tests/test_event_deserializer.py
@@ -13,23 +13,23 @@ class TestEventDeserializer(unittest.TestCase):
         data = json.dumps({
             "type": "MCOStartEvent",
             "model_data": {
-                "input_names": ["a", "b"],
-                "output_names": ["c", "d"]
+                "parameter_names": ["a", "b"],
+                "kpi_names": ["c", "d"]
             }
         })
 
         event = EventDeserializer().deserialize(data)
         self.assertIsInstance(event, MCOStartEvent)
-        self.assertEqual(event.input_names, event.input_names)
-        self.assertEqual(event.output_names, event.output_names)
+        self.assertEqual(event.parameter_names, event.parameter_names)
+        self.assertEqual(event.kpi_names, event.kpi_names)
 
     def test_invalid_cases(self):
         invalid_cases = [
             {
                 "type": "Foo",
                 "model_data": {
-                    "input_names": ["a", "b"],
-                    "output_names": ["c", "d"]
+                    "parameter_names": ["a", "b"],
+                    "kpi_names": ["c", "d"]
                 }
             },
             {

--- a/force_wfmanager/server/tests/test_event_deserializer.py
+++ b/force_wfmanager/server/tests/test_event_deserializer.py
@@ -55,7 +55,6 @@ class TestEventDeserializer(unittest.TestCase):
 
         self.assertEqual(event.weights, [1.0])
 
-
     def test_invalid_cases(self):
         invalid_cases = [
             {

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -15,7 +15,7 @@ from force_bdss.tests.probe_classes.factory_registry_plugin import \
     ProbeFactoryRegistryPlugin, ProbeExtensionPlugin
 from force_bdss.api import (MCOStartEvent, MCOProgressEvent, Workflow,
                             WorkflowWriter, WorkflowReader,
-                            InvalidFileException)
+                            InvalidFileException, DataValue)
 
 from force_wfmanager.central_pane.analysis_model import AnalysisModel
 from force_wfmanager.server.zmq_server import ZMQServer
@@ -534,19 +534,25 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
         self.assertEqual(self.wfmanager_task.analysis_m.value_names, ())
         with self.event_loop():
             send_event(MCOStartEvent(
-                input_names=("x",),
-                output_names=("y",)
-            ))
+                parameter_names=["x"],
+                kpi_names=["y"])
+            )
 
         self.assertEqual(
             len(self.wfmanager_task.analysis_m.evaluation_steps),
             0)
         self.assertEqual(
             self.wfmanager_task.analysis_m.value_names,
-            ('x', 'y'))
+            ('x', 'y', 'y weight'))
 
         with self.event_loop():
-            send_event(MCOProgressEvent(input=["1.0"], output=["2.0"]))
+            send_event(MCOProgressEvent(
+                optimal_point=[
+                    DataValue(value=1.0)],
+                optimal_kpis=[
+                    DataValue(value=2.0)
+                ],
+                weights=[1.0]))
 
         self.assertEqual(
             len(self.wfmanager_task.analysis_m.evaluation_steps),

--- a/force_wfmanager/tests/test_wfmanager_task.py
+++ b/force_wfmanager/tests/test_wfmanager_task.py
@@ -548,7 +548,8 @@ class TestWFManagerTask(GuiTestAssistant, unittest.TestCase):
         with self.event_loop():
             send_event(MCOProgressEvent(
                 optimal_point=[
-                    DataValue(value=1.0)],
+                    DataValue(value=1.0)
+                ],
                 optimal_kpis=[
                     DataValue(value=2.0)
                 ],

--- a/force_wfmanager/wfmanager_task.py
+++ b/force_wfmanager/wfmanager_task.py
@@ -488,10 +488,17 @@ class WfManagerTask(Task):
         action appropriately according to the type"""
         if isinstance(event, MCOStartEvent):
             self.analysis_m.clear()
-            self.analysis_m.value_names = (
-                event.input_names + event.output_names)
+            value_names = list(event.parameter_names)
+            for kpi_name in event.kpi_names:
+                value_names.extend([kpi_name, kpi_name+" weight"])
+            self.analysis_m.value_names = tuple(value_names)
+
         elif isinstance(event, MCOProgressEvent):
-            data = tuple(map(float, event.input + event.output))
+            data = [dv.value for dv in event.optimal_point]
+            for kpi, weight in zip(event.optimal_kpis, event.weights):
+                data.extend([kpi.value, weight])
+
+            data = tuple(map(float, data))
             self.analysis_m.add_evaluation_step(data)
 
     def _show_error_dialog(self, message):


### PR DESCRIPTION
After PR 187 in force-bdss, this PR syncs the wfmanager plugin against the changes in MCOProgressEvent and MCO.
