### PR TITLE
Move Datasource/MCO/Notification Listener instance view to Setup Pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ __pycache__
 force_wfmanager/version.py
 doc/build/
 *.pyc
+.DS_Store
+.coverage
+*.json
+*.log
+*.csv

--- a/force_wfmanager/central_pane/setup_pane.py
+++ b/force_wfmanager/central_pane/setup_pane.py
@@ -10,7 +10,6 @@ from traitsui.editors import ShellEditor, InstanceEditor
 from traitsui.handler import ModelView
 
 from force_bdss.api import Workflow
-from force_wfmanager.left_side_pane.new_entity_modal import NewEntityModal
 
 
 class SetupPane(TraitsTaskPane):

--- a/force_wfmanager/central_pane/setup_pane.py
+++ b/force_wfmanager/central_pane/setup_pane.py
@@ -1,9 +1,12 @@
 from pyface.tasks.api import TraitsTaskPane
 
 from traits.api import Instance, Dict
+from traits.has_traits import on_trait_change
+from traits.trait_types import String
 
 from traitsui.api import View, VGroup, UItem
-from traitsui.editors import ShellEditor
+from traitsui.editors import ShellEditor, InstanceEditor
+from traitsui.handler import ModelView
 
 from .analysis_model import AnalysisModel
 
@@ -18,10 +21,18 @@ class SetupPane(TraitsTaskPane):
     # Namespace for the console
     console_ns = Dict()
 
-    view = View(VGroup(
-            UItem("console_ns", label="Console", editor=ShellEditor()),
-    ),
-    )
+    selected_mv = Instance(ModelView)
+
+    selected_factory_group = String('Workflow')
+
+    view = View(
+        VGroup(
+                UItem("selected_mv", editor=InstanceEditor(), style="custom",
+                      visible_when="selected_factory_group == 'None'"),
+                UItem("console_ns", label="Console", editor=ShellEditor()),
+                layout='tabbed'
+                ),
+            )
 
     def __init__(self, analysis_model, *args, **kwargs):
         super(SetupPane, self).__init__(*args, **kwargs)
@@ -37,3 +48,12 @@ class SetupPane(TraitsTaskPane):
             namespace["app"] = None
 
         return namespace
+
+    @on_trait_change('task.side_pane.workflow_tree.selected_factory_group')
+    def set_selected_factory_group(self):
+        selected = self.task.side_pane.workflow_tree.selected_factory_group
+        self.selected_factory_group = selected
+
+    @on_trait_change('task.side_pane.workflow_tree.selected_mv')
+    def set_selected_mv(self):
+        self.selected_mv = self.task.side_pane.workflow_tree.selected_mv

--- a/force_wfmanager/left_side_pane/data_source_model_view.py
+++ b/force_wfmanager/left_side_pane/data_source_model_view.py
@@ -164,8 +164,7 @@ class DataSourceModelView(ModelView):
                 show_border=True
             ),
         ),
-        kind="subpanel",
-        )
+    )
 
     def __init__(self, model, variable_names_registry, *args, **kwargs):
         self.model = model

--- a/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/left_side_pane/tests/test_kpi_specification_model_view.py
@@ -52,15 +52,15 @@ class TestKPISpecificationModelViewTest(unittest.TestCase, UnittestTools):
             variable_names_registry=self.registry
         )
         self.assertEqual(self.kpi_specification_mv_named.label,
-                         "KPI: T1")
+                         "KPI: T1 (MINIMISE)")
 
         self.kpi_specification_objective = KPISpecification(
-            name='T1', objective='MINIMISE')
+            name='T1', objective='MAXIMISE')
         self.kpi_specification_mv_objective = KPISpecificationModelView(
             model=self.kpi_specification_objective,
             variable_names_registry=self.registry)
         self.assertEqual(self.kpi_specification_mv_objective.label,
-                         "KPI: T1 (MINIMISE)")
+                         "KPI: T1 (MAXIMISE)")
 
     def test_name_change(self):
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
@@ -71,7 +71,7 @@ class TestKPISpecificationModelViewTest(unittest.TestCase, UnittestTools):
                                      count=1):
             self.kpi_specification_mv.model.name = 'T1'
             self.assertEqual(self.kpi_specification_mv.label,
-                             'KPI: T1')
+                             'KPI: T1 (MINIMISE)')
         self.kpi_specification_mv_nomodel = KPISpecificationModelView(
             model=None, variable_names_registry=self.registry)
         self.assertEqual(self.kpi_specification_mv_nomodel.name, '')

--- a/force_wfmanager/left_side_pane/workflow_tree.py
+++ b/force_wfmanager/left_side_pane/workflow_tree.py
@@ -113,8 +113,6 @@ class ModelEditDialog(ModelView):
         )
 
 
-
-
 class WorkflowTree(ModelView):
     """ Part of the GUI containing the tree editor displaying the Workflow """
 
@@ -236,7 +234,8 @@ class WorkflowTree(ModelView):
                 menu=Menu(edit_data_source_action, delete_data_source_action),
             ),
         ],
-        orientation="vertical",
+        orientation="horizontal",
+        editable=False,
         selected="selected_mv",
     )
 
@@ -252,7 +251,9 @@ class WorkflowTree(ModelView):
     #: The currently selected modelview
     selected_mv = Instance(ModelView)
 
-    #: The output type of the currently selected factory group
+    #: The name of the currently selected factory group. This will be None
+    #: if an actual modelview is selected, or (for example) 'MCO' if the
+    #: MCO folder is selected
     selected_factory_group = Unicode()
 
     #: The error message relating to selected_mv
@@ -290,14 +291,22 @@ class WorkflowTree(ModelView):
         super(WorkflowTree, self).__init__(*args, **kwargs)
         self.model = model
         self._factory_registry = factory_registry
+        # Set up handlers for nodes being selected
+        self.assign_tree_node_select_action()
+
+    def set_factory_group(self, name, mv):
+        """Sets the selected_factory_group to be the correct name.
+        Called on selection of a node in the workflow tree."""
+        self.selected_factory_group = name
+
+    def assign_tree_node_select_action(self):
+        """ Set factory group to the node's name on selction,
+        if the node has children or is the root Workflow node"""
         for node in self.tree_editor.nodes:
             if node.children != '' or node.node_for == [WorkflowModelView]:
                 node.on_select = partial(self.set_factory_group, node.name)
             else:
                 node.on_select = partial(self.set_factory_group, 'None')
-
-    def set_factory_group(self, name, mv):
-        self.selected_factory_group = name
 
     def _workflow_mv_default(self):
         return WorkflowModelView(model=self.model)

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -216,7 +216,7 @@ class WfManagerSetupTask(Task):
         """ Creates the central pane which contains the analysis part
         (pareto front and output KPI values)
         """
-        return SetupPane()
+        return SetupPane(workflow_m=self.workflow_m)
 
     def create_dock_panes(self):
         """ Creates the dock panes """

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -212,7 +212,7 @@ class WfManagerSetupTask(Task):
         """ Creates the central pane which contains the analysis part
         (pareto front and output KPI values)
         """
-        return SetupPane(workflow_m=self.workflow_m)
+        return SetupPane(workflow_model=self.workflow_model)
 
     def create_dock_panes(self):
         """ Creates the dock panes """


### PR DESCRIPTION
[NOTE] Relies on https://github.com/force-h2020/force-wfmanager/pull/239 being merged first.
Moves UI elements from being integrated into the workflow tree pane to being located in the Setup Pane.
This could also be done by changing the orientation of the workflow tree, however this may not be so useful if we want to share the Setup Pane between factory selection and modelview representation.  