### PR TITLE
Pass the variable names registry to notification listener modelview

### DIFF
--- a/force_wfmanager/left_side_pane/notification_listener_model_view.py
+++ b/force_wfmanager/left_side_pane/notification_listener_model_view.py
@@ -2,6 +2,9 @@ from traits.api import Instance, Unicode, Bool, Event
 from traitsui.api import ModelView
 
 from force_bdss.api import BaseNotificationListenerModel
+from force_wfmanager.left_side_pane.variable_names_registry import (
+    VariableNamesRegistry
+)
 from force_wfmanager.left_side_pane.view_utils import get_factory_name
 
 
@@ -13,6 +16,9 @@ class NotificationListenerModelView(ModelView):
 
     #: The model object this MV wraps
     model = Instance(BaseNotificationListenerModel)
+
+    #: Registry of the available variables
+    variable_names_registry = Instance(VariableNamesRegistry)
 
     # ------------------
     # Regular Attributes

--- a/force_wfmanager/left_side_pane/workflow_model_view.py
+++ b/force_wfmanager/left_side_pane/workflow_model_view.py
@@ -139,6 +139,7 @@ class WorkflowModelView(ModelView):
         self.notification_listeners_mv = [
             NotificationListenerModelView(
                 model=notification_listener,
+                variable_names_registry=self.variable_names_registry
             )
             for notification_listener in self.model.notification_listeners
             if notification_listener.factory.ui_visible is True

--- a/force_wfmanager/test.txt
+++ b/force_wfmanager/test.txt
@@ -1,0 +1,1 @@
+testing ci integration

--- a/force_wfmanager/test.txt
+++ b/force_wfmanager/test.txt
@@ -1,1 +1,1 @@
-testing ci integration again x2
+testing ci integration again x2 and again x3

--- a/force_wfmanager/test.txt
+++ b/force_wfmanager/test.txt
@@ -1,1 +1,1 @@
-testing ci integration
+testing ci integration again

--- a/force_wfmanager/test.txt
+++ b/force_wfmanager/test.txt
@@ -1,1 +1,1 @@
-testing ci integration again
+testing ci integration again x2


### PR DESCRIPTION
So this is something that will be needed to support a notification listener which maps datavalues from a run to database attributes.. but this is mostly to test if travis CI is still working