### PR TITLE
Improved ResultsPane performance with TabularEditor and enabled multi-point selections

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -16,6 +16,9 @@ ADDITIONAL_CORE_DEPS = [
     "pyzmq==16.0.0-4",
 ]
 
+# Pick particular TraitsUI commit until TabularEditor fixes are merged.
+PIP_DEPS = ['git+https://github.com/enthought/traitsui.git@8302d8a09f3c05798ff588c3e6f46634d7ae1613']
+
 
 @click.group()
 def cli():
@@ -38,6 +41,7 @@ def install(python_version):
         "edm", "install", "-e", env_name,
         "--yes"] + ADDITIONAL_CORE_DEPS)
 
+    edm_run(env_name, ["pip", "install"] + [dep for dep in PIP_DEPS])
     edm_run(env_name, ["pip", "install", "-e", "."])
 
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -17,7 +17,8 @@ ADDITIONAL_CORE_DEPS = [
 ]
 
 # Pick particular TraitsUI commit until TabularEditor fixes are merged.
-PIP_DEPS = ['git+https://github.com/enthought/traitsui.git@8302d8a09f3c05798ff588c3e6f46634d7ae1613']
+PIP_DEPS = ['git+https://github.com/enthought/traitsui.git'
+            '@8302d8a09f3c05798ff588c3e6f46634d7ae1613']
 
 
 @click.group()

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -72,11 +72,12 @@ class AnalysisModel(HasStrictTraits):
         return self._selected_step_indices
 
     def _set_selected_step_indices(self, values):
-        if values:
-            self._selected_step_indices = values
+        self._selected_step_indices = values
+        if values is not None:
             for value in values:
                 if (isinstance(value, int) and not
                         (0 <= value < len(self._evaluation_steps))):
+                    self._selected_step_indices = None
                     raise ValueError(
                         "Invalid value for selection index {}. Current "
                         "number of steps = {}".format(

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -72,12 +72,14 @@ class AnalysisModel(HasStrictTraits):
         return self._selected_step_indices
 
     def _set_selected_step_indices(self, values):
-        self._selected_step_indices = values
+        """ Check the requested indices of selected rows, and use the
+        requested values if they exist in the table, or are None.
+
+        """
         if values is not None:
             for value in values:
                 if (isinstance(value, int) and not
                         (0 <= value < len(self._evaluation_steps))):
-                    self._selected_step_indices = None
                     raise ValueError(
                         "Invalid value for selection index {}. Current "
                         "number of steps = {}".format(
@@ -85,6 +87,8 @@ class AnalysisModel(HasStrictTraits):
                             len(self._evaluation_steps)
                         )
                     )
+
+        self._selected_step_indices = values
 
     def clear(self):
         """ Sets :attr:`value_names` to be empty, removes all entries in the

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -20,7 +20,7 @@ class AnalysisModel(HasStrictTraits):
 
     #: Selected step, used for highlighting in the table/plot.
     #: Listens to: :attr:`value_names`
-    _selected_step_index = Either(None, Int())
+    _selected_step_indices = Either(None, List(Int()))
 
     # ----------
     # Properties
@@ -37,13 +37,13 @@ class AnalysisModel(HasStrictTraits):
     #: in the allowed range of values.
     #: Listens to :attr:`Plot._plot_index_datasource
     #: <force_wfmanager.central_pane.plot.Plot._plot_index_datasource>`
-    selected_step_index = Property(Either(None, Int),
-                                   depends_on="_selected_step_index")
+    selected_step_indices = Property(Either(None, List(Int)),
+                                     depends_on="_selected_step_indices")
 
     @on_trait_change("value_names")
     def _clear_evaluation_steps(self):
         self._evaluation_steps[:] = []
-        self._selected_step_index = None
+        self._selected_step_indices = None
 
     def _get_evaluation_steps(self):
         return self._evaluation_steps
@@ -68,31 +68,33 @@ class AnalysisModel(HasStrictTraits):
 
         self._evaluation_steps.append(evaluation_step)
 
-    def _get_selected_step_index(self):
-        return self._selected_step_index
+    def _get_selected_step_indices(self):
+        return self._selected_step_indices
 
-    def _set_selected_step_index(self, value):
-        if (isinstance(value, int) and not
-                (0 <= value < len(self._evaluation_steps))):
-            raise ValueError(
-                "Invalid value for selection index {}. Current "
-                "number of steps = {}".format(
-                    value,
-                    len(self._evaluation_steps)
-                )
-            )
-
-        self._selected_step_index = value
+    def _set_selected_step_indices(self, values):
+        if values:
+            self._selected_step_indices = values
+            for value in values:
+                if (isinstance(value, int) and not
+                        (0 <= value < len(self._evaluation_steps))):
+                    raise ValueError(
+                        "Invalid value for selection index {}. Current "
+                        "number of steps = {}".format(
+                            value,
+                            len(self._evaluation_steps)
+                        )
+                    )
 
     def clear(self):
         """ Sets :attr:`value_names` to be empty, removes all entries in the
-        list :attr:`evaluation_steps` and sets :attr:`selected_step_index`
+        list :attr:`evaluation_steps` and sets :attr:`selected_step_indices`
         to None"""
         self.value_names = ()
+        self._clear_evaluation_steps()
 
     def clear_steps(self):
         """ Removes all entries in the list :attr:`evaluation_steps` and sets
-        :attr:`selected_step_index` to None but does not clear
+        :attr:`selected_step_indices` to None but does not clear
         :attr:`value_names`
         """
         self._clear_evaluation_steps()

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -2,6 +2,7 @@ from chaco.api import ArrayPlotData, ArrayDataSource, ScatterInspectorOverlay
 from chaco.api import Plot as ChacoPlot
 from chaco.tools.api import PanTool, ScatterInspector, ZoomTool
 from enable.api import Component, ComponentEditor
+from enable.api import KeySpec
 from traits.api import (
     Button, Bool, Enum, HasStrictTraits, Instance, List, Property, Tuple,
     on_trait_change
@@ -111,22 +112,28 @@ class Plot(HasStrictTraits):
         plot.set(title="Plot", padding=75, line_width=1)
 
         # Add pan and zoom tools
-        plot.tools.append(PanTool(plot))
-        plot.overlays.append(ZoomTool(plot))
+        scatter_plot.tools.append(PanTool(plot))
+        scatter_plot.overlays.append(ZoomTool(plot))
+
+        # Set the scatterplot's default selection marker invisible as it
+        # lead to artifacts on axis when switching between plotted cols
+        scatter_plot.set(selection_color=(0, 0, 0, 0),
+                         selection_outline_color=(0, 0, 0, 0))
 
         # Add the selection tool
         scatter_plot.tools.append(ScatterInspector(
             scatter_plot,
             threshold=10,
+            multiselect_modifier=KeySpec(None, "shift"),
             selection_mode="multi",
         ))
         overlay = ScatterInspectorOverlay(
             scatter_plot,
-            hover_color="blue",
+            hover_color=(0, 0, 1, 1),
             hover_marker_size=6,
-            selection_marker_size=6,
-            selection_color="blue",
-            selection_outline_color="blue",
+            selection_marker_size=20,
+            selection_color=(0, 0, 1, 0.5),
+            selection_outline_color=(0, 0, 0, 0.8),
             selection_line_width=3)
         scatter_plot.overlays.append(overlay)
 

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -60,10 +60,10 @@ class Plot(HasStrictTraits):
     _plot_data = Instance(ArrayPlotData)
 
     #: Datasource of the plot (used for selection handling)
-    #: Listens to: :attr:`analysis_model.selected_step_index
+    #: Listens to: :attr:`analysis_model.selected_step_indices
     #: <force_wfmanager.central_pane.analysis_model.AnalysisModel.\
-    #: selected_step_index>`
-    _plot_index_datasource = Instance(ArrayDataSource)
+    #: selected_step_indices>`
+    _plot_indices_datasource = Instance(ArrayDataSource)
 
     # ----------
     # Properties
@@ -118,7 +118,7 @@ class Plot(HasStrictTraits):
         scatter_plot.tools.append(ScatterInspector(
             scatter_plot,
             threshold=10,
-            selection_mode="single",
+            selection_mode="multi",
         ))
         overlay = ScatterInspectorOverlay(
             scatter_plot,
@@ -131,7 +131,7 @@ class Plot(HasStrictTraits):
         scatter_plot.overlays.append(overlay)
 
         # Initialize plot datasource
-        self._plot_index_datasource = scatter_plot.index
+        self._plot_indices_datasource = scatter_plot.index
 
         return plot
 
@@ -304,25 +304,24 @@ class Plot(HasStrictTraits):
                     y_data[0] + 0.5)
         return None
 
-    @on_trait_change('analysis_model.selected_step_index')
-    def update_selected_point(self):
-        """ Updates the selected point in the plot according to the model """
-        if self.analysis_model.selected_step_index is None:
-            self._plot_index_datasource.metadata['selections'] = []
+    @on_trait_change('analysis_model.selected_step_indices')
+    def update_selected_points(self):
+        """ Updates the selected points in the plot according to the model """
+        if self.analysis_model.selected_step_indices is None:
+            self._plot_indices_datasource.metadata['selections'] = []
         else:
-            self._plot_index_datasource.metadata['selections'] = [
-                self.analysis_model.selected_step_index
-            ]
+            self._plot_indices_datasource.metadata['selections'] = \
+                self.analysis_model.selected_step_indices
 
-    @on_trait_change('_plot_index_datasource.metadata_changed')
+    @on_trait_change('_plot_indices_datasource.metadata_changed')
     def update_model(self):
         """ Updates the model according to the selected point in the plot """
-        selected_indices = self._plot_index_datasource.metadata.get(
+        selected_indices = self._plot_indices_datasource.metadata.get(
             'selections', [])
         if len(selected_indices) == 0:
-            self.analysis_model.selected_step_index = None
+            self.analysis_model.selected_step_indices = None
         else:
-            self.analysis_model.selected_step_index = selected_indices[0]
+            self.analysis_model.selected_step_indices = selected_indices
 
     def _set_plot_range(self, x_low, x_high, y_low, y_high):
         """ Helper method to set the size of the current _plot

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -64,7 +64,7 @@ class Plot(HasStrictTraits):
     #: Listens to: :attr:`analysis_model.selected_step_indices
     #: <force_wfmanager.central_pane.analysis_model.AnalysisModel.\
     #: selected_step_indices>`
-    _plot_indices_datasource = Instance(ArrayDataSource)
+    _plot_index_datasource = Instance(ArrayDataSource)
 
     # ----------
     # Properties
@@ -138,7 +138,7 @@ class Plot(HasStrictTraits):
         scatter_plot.overlays.append(overlay)
 
         # Initialize plot datasource
-        self._plot_indices_datasource = scatter_plot.index
+        self._plot_index_datasource = scatter_plot.index
 
         return plot
 
@@ -315,15 +315,15 @@ class Plot(HasStrictTraits):
     def update_selected_points(self):
         """ Updates the selected points in the plot according to the model """
         if self.analysis_model.selected_step_indices is None:
-            self._plot_indices_datasource.metadata['selections'] = []
+            self._plot_index_datasource.metadata['selections'] = []
         else:
-            self._plot_indices_datasource.metadata['selections'] = \
+            self._plot_index_datasource.metadata['selections'] = \
                 self.analysis_model.selected_step_indices
 
-    @on_trait_change('_plot_indices_datasource.metadata_changed')
+    @on_trait_change('_plot_index_datasource.metadata_changed')
     def update_model(self):
         """ Updates the model according to the selected point in the plot """
-        selected_indices = self._plot_indices_datasource.metadata.get(
+        selected_indices = self._plot_index_datasource.metadata.get(
             'selections', [])
         if len(selected_indices) == 0:
             self.analysis_model.selected_step_indices = None

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -1,5 +1,6 @@
 from traits.api import (
-    Either, HasStrictTraits, Instance, List, Property, Tuple, on_trait_change
+    Either, HasStrictTraits, Instance, List, Property, Tuple, on_trait_change,
+    Event, Int
 )
 from traitsui.api import TabularEditor, UItem, View
 from traitsui.tabular_adapter import TabularAdapter
@@ -26,6 +27,10 @@ class ResultTable(HasStrictTraits):
 
     #: Selected evaluation steps in the table
     _selected_rows = Either(List(Tuple), None)
+
+    #: When the selected row changes, this event will be triggered
+    #: to return the index of that row, so that it can be scrolled to
+    _scroll_to_row = Event(Int)
 
     # ----------
     # Properties
@@ -55,7 +60,11 @@ class ResultTable(HasStrictTraits):
     def traits_view(self):
         editor = TabularEditor(adapter=self.tabular_adapter,
                                show_titles=True,
+                               selected="_selected_rows",
                                auto_update=False,
+                               multi_select=True,
+                               scroll_to_row='_scroll_to_row',
+                               scroll_to_row_hint='visible',
                                editable=False)
 
         return View(UItem("rows", editor=editor))
@@ -88,3 +97,4 @@ class ResultTable(HasStrictTraits):
             self.analysis_model.selected_step_index = \
                 self.analysis_model.evaluation_steps.index(
                     self._selected_rows[0])
+            self._scroll_to_row = self.analysis_model.selected_step_index

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -77,14 +77,14 @@ class ResultTable(HasStrictTraits):
         self.tabular_adapter.format = '% 5.4E'
 
     # Response to model change
-    @on_trait_change('analysis_model.selected_step_index')
+    @on_trait_change('analysis_model.selected_step_indices')
     def update_table(self):
         """ Updates the selected row in the table according to the model """
-        if self.analysis_model.selected_step_index is None:
+        if self.analysis_model.selected_step_indices is None:
             self._selected_rows = []
         else:
             self._selected_rows = [
-                self.rows[self.analysis_model.selected_step_index]
+                self.rows[ind] for ind in self.analysis_model.selected_step_indices
             ]
 
     # Response to new selection by user in UI
@@ -92,9 +92,10 @@ class ResultTable(HasStrictTraits):
     def update_model(self):
         """ Updates the model according to the selected row in the table """
         if not self._selected_rows:
-            self.analysis_model.selected_step_index = None
+            self.analysis_model.selected_step_indices = None
         else:
-            self.analysis_model.selected_step_index = \
-                self.analysis_model.evaluation_steps.index(
-                    self._selected_rows[0])
-            self._scroll_to_row = self.analysis_model.selected_step_index
+            self.analysis_model.selected_step_indices = [
+                self.analysis_model.evaluation_steps.index(row)
+                for row in self._selected_rows
+            ]
+            self._scroll_to_row = self.analysis_model.selected_step_indices[0]

--- a/force_wfmanager/central_pane/result_table.py
+++ b/force_wfmanager/central_pane/result_table.py
@@ -84,7 +84,8 @@ class ResultTable(HasStrictTraits):
             self._selected_rows = []
         else:
             self._selected_rows = [
-                self.rows[ind] for ind in self.analysis_model.selected_step_indices
+                self.rows[ind]
+                for ind in self.analysis_model.selected_step_indices
             ]
 
     # Response to new selection by user in UI
@@ -92,7 +93,7 @@ class ResultTable(HasStrictTraits):
     def update_model(self):
         """ Updates the model according to the selected row in the table """
         if not self._selected_rows:
-            self.analysis_model.selected_step_indices = None
+            self.analysis_model._selected_step_indices = None
         else:
             self.analysis_model.selected_step_indices = [
                 self.analysis_model.evaluation_steps.index(row)

--- a/force_wfmanager/central_pane/tests/test_analysis_model.py
+++ b/force_wfmanager/central_pane/tests/test_analysis_model.py
@@ -12,7 +12,7 @@ class TestAnalysisModel(unittest.TestCase):
     def test_analysis_init(self):
         self.assertEqual(len(self.analysis.value_names), 0)
         self.assertEqual(len(self.analysis.evaluation_steps), 0)
-        self.assertEqual(self.analysis.selected_step_index, None)
+        self.assertEqual(self.analysis.selected_step_indices, None)
 
     def test_add_evaluation_step(self):
         self.analysis.value_names = ('foo', 'bar')
@@ -34,24 +34,30 @@ class TestAnalysisModel(unittest.TestCase):
         self.analysis.add_evaluation_step((3, 4))
         self.analysis.add_evaluation_step((5, 6))
 
-        self.analysis.selected_step_index = 0
-        self.analysis.selected_step_index = 2
-        self.analysis.selected_step_index = None
-
-        with self.assertRaises(ValueError):
-            self.analysis.selected_step_index = 3
+        self.analysis.selected_step_indices = [0]
+        self.analysis.selected_step_indices = [2]
+        self.analysis.selected_step_indices = None
 
         with self.assertRaises(TraitError):
-            self.analysis.selected_step_index = 3.0
+            self.analysis.selected_step_indices = 1
 
         with self.assertRaises(ValueError):
-            self.analysis.selected_step_index = -1
+            self.analysis.selected_step_indices = [3]
 
         with self.assertRaises(TraitError):
-            self.analysis.selected_step_index = "hello"
+            self.analysis.selected_step_indices = [3.0]
+
+        with self.assertRaises(ValueError):
+            self.analysis.selected_step_indices = [-1]
+
+        with self.assertRaises(TraitError):
+            self.analysis.selected_step_indices = "hello"
+
+        with self.assertRaises(TraitError):
+            self.analysis.selected_step_indices = ["hello"]
 
         self.analysis.value_names = ('bar', 'baz')
-        self.assertEqual(self.analysis.selected_step_index, None)
+        self.assertEqual(self.analysis.selected_step_indices, None)
         self.assertEqual(self.analysis.evaluation_steps, [])
 
     def test_clear(self):
@@ -59,10 +65,10 @@ class TestAnalysisModel(unittest.TestCase):
         self.analysis.add_evaluation_step((1, 2))
         self.analysis.add_evaluation_step((3, 4))
         self.analysis.add_evaluation_step((5, 6))
-        self.analysis.selected_step_index = 0
+        self.analysis.selected_step_indices = [0]
 
         self.analysis.clear()
 
         self.assertEqual(self.analysis.value_names, ())
         self.assertEqual(self.analysis.evaluation_steps, [])
-        self.assertEqual(self.analysis.selected_step_index, None)
+        self.assertEqual(self.analysis.selected_step_indices, None)

--- a/force_wfmanager/central_pane/tests/test_analysis_model.py
+++ b/force_wfmanager/central_pane/tests/test_analysis_model.py
@@ -66,6 +66,16 @@ class TestAnalysisModel(unittest.TestCase):
         self.analysis.add_evaluation_step((3, 4))
         self.analysis.add_evaluation_step((5, 6))
         self.analysis.selected_step_indices = [0]
+        self.analysis.selected_step_indices = [0, 1, 2]
+        self.analysis.selected_step_indices = [0, 2]
+
+        with self.assertRaises(ValueError):
+            self.analysis.selected_step_indices = [0, 3]
+        with self.assertRaises(ValueError):
+            self.analysis.selected_step_indices = [5, 6]
+
+        with self.assertRaises(TraitError):
+            self.analysis.selected_step_indices = 0
 
         self.analysis.clear()
 

--- a/force_wfmanager/central_pane/tests/test_graph_pane.py
+++ b/force_wfmanager/central_pane/tests/test_graph_pane.py
@@ -12,7 +12,7 @@ class TestGraphPane(unittest.TestCase):
     def test_pane_init(self):
         self.assertEqual(len(self.pane.analysis_model.value_names), 0)
         self.assertEqual(len(self.pane.analysis_model.evaluation_steps), 0)
-        self.assertIsNone(self.pane.analysis_model.selected_step_index)
+        self.assertIsNone(self.pane.analysis_model.selected_step_indices)
 
         self.assertEqual(
             self.pane.plot.analysis_model.evaluation_steps,

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -160,19 +160,19 @@ class TestPlot(unittest.TestCase):
 
         # From plot to the model
         plot_metadata['selections'] = [1]
-        self.assertEqual(self.analysis_model.selected_step_index, 1)
+        self.assertEqual(self.analysis_model.selected_step_indices, [1])
 
         plot_metadata['selections'] = [0]
-        self.assertEqual(self.analysis_model.selected_step_index, 0)
+        self.assertEqual(self.analysis_model.selected_step_indices, [0])
 
         plot_metadata['selections'] = []
-        self.assertIsNone(self.analysis_model.selected_step_index)
+        self.assertIsNone(self.analysis_model.selected_step_indices)
 
         # From model to the plot
-        self.analysis_model.selected_step_index = 1
+        self.analysis_model.selected_step_indices = [1]
         self.assertEqual(plot_metadata['selections'], [1])
 
-        self.analysis_model.selected_step_index = None
+        self.analysis_model.selected_step_indices = None
         self.assertEqual(plot_metadata['selections'], [])
 
     def test_resize_plot(self):

--- a/force_wfmanager/central_pane/tests/test_result_table.py
+++ b/force_wfmanager/central_pane/tests/test_result_table.py
@@ -30,21 +30,25 @@ class TestResultTable(unittest.TestCase):
 
     def test_selection(self):
         # From table to the model
-        self.assertIsNone(self.analysis_model.selected_step_index)
+        self.assertIsNone(self.analysis_model.selected_step_indices)
 
         self.result_table._selected_rows = [(2.1, 56, 'CO')]
-        self.assertEqual(self.analysis_model.selected_step_index, 0)
+        self.assertEqual(self.analysis_model.selected_step_indices, [0])
 
         self.result_table._selected_rows = [(1.23, 51.2, 'CO2')]
-        self.assertEqual(self.analysis_model.selected_step_index, 1)
+        self.assertEqual(self.analysis_model.selected_step_indices, [1])
 
         self.result_table._selected_rows = []
-        self.assertIsNone(self.analysis_model.selected_step_index)
+        self.assertIsNone(self.analysis_model.selected_step_indices)
 
         # From model to the table
-        self.analysis_model.selected_step_index = 1
+        self.analysis_model.selected_step_indices = [1]
         self.assertEqual(self.result_table._selected_rows,
                          [(1.23, 51.2, 'CO2')])
 
-        self.analysis_model.selected_step_index = None
+        self.analysis_model.selected_step_indices = [0, 1]
+        self.assertEqual(self.result_table._selected_rows,
+                         [(2.1, 56, 'CO'), (1.23, 51.2, 'CO2')])
+
+        self.analysis_model.selected_step_indices = None
         self.assertEqual(self.result_table._selected_rows, [])

--- a/force_wfmanager/gui/tests/test_click_run.py
+++ b/force_wfmanager/gui/tests/test_click_run.py
@@ -1,9 +1,12 @@
 import unittest
+import sys
+import os
 from unittest import mock
 
 from click.testing import CliRunner
 
 import force_wfmanager.gui.run
+from force_wfmanager.version import __version__
 from force_wfmanager.wfmanager import WfManager
 
 
@@ -38,7 +41,29 @@ class TestClickRun(unittest.TestCase):
         with mock.patch('force_wfmanager.gui.run.WfManager') as mock_wf:
             mock_wf.return_value = MockWfManager()
             force_wfmanager.gui.run.main(
-                window_size=(1650, 1080), debug=True, workflow_file=None
+                window_size=(1650, 1080),
+                debug=True,
+                profile=False,
+                workflow_file=None
             )
             self.log = force_wfmanager.gui.run.logging.getLogger(__name__)
             self.assertEqual(self.log.getEffectiveLevel(), 10)
+
+    def test_run_with_profile(self):
+        with mock.patch('force_wfmanager.gui.run.WfManager') as mock_wf:
+            mock_wf.return_value = MockWfManager()
+            force_wfmanager.gui.run.main(
+                window_size=(1650, 1080), debug=False,
+                profile=True, workflow_file=None
+            )
+            root = ('force_wfmanager-{}-{}.{}.{}'
+                    .format(__version__,
+                            sys.version_info.major,
+                            sys.version_info.minor,
+                            sys.version_info.micro))
+            exts = ['.pstats', '.prof']
+            files_exist = [False] * len(exts)
+            for ind, ext in enumerate(exts):
+                files_exist[ind] = os.path.isfile(root + ext)
+                os.remove(root + ext)
+            self.assertTrue(all(files_exist))

--- a/force_wfmanager/left_side_pane/tests/test_result_pane.py
+++ b/force_wfmanager/left_side_pane/tests/test_result_pane.py
@@ -12,7 +12,7 @@ class TestResultsPane(unittest.TestCase):
     def test_pane_init(self):
         self.assertEqual(len(self.pane.analysis_model.value_names), 0)
         self.assertEqual(len(self.pane.analysis_model.evaluation_steps), 0)
-        self.assertIsNone(self.pane.analysis_model.selected_step_index)
+        self.assertIsNone(self.pane.analysis_model.selected_step_indices)
 
         self.assertEqual(
             self.pane.result_table.analysis_model.evaluation_steps,

--- a/force_wfmanager/left_side_pane/workflow_info.py
+++ b/force_wfmanager/left_side_pane/workflow_info.py
@@ -111,7 +111,11 @@ class WorkflowInfo(HasTraits):
                 visible_when="selected_factory == 'Workflow'"
             ),
 
-            horizontal_centre(UItem('image', editor=ImageEditor())),
+            horizontal_centre(
+                UItem('image', editor=ImageEditor(scale=True,
+                                                  allow_upscaling=False,
+                                                  preserve_aspect_ratio=True))
+            ),
 
         )
     )

--- a/force_wfmanager/local_traits.py
+++ b/force_wfmanager/local_traits.py
@@ -11,7 +11,7 @@ class ZMQSocketURL(BaseUnicode):
         """Checks that this is a valid tcp address """
         super(ZMQSocketURL, self).validate(object, name, value)
         m = re.match(
-            "tcp://(\\d{1,3})\.(\\d{1,3})\.(\\d{1,3})\.(\\d{1,3}):(\\d+)",
+            "tcp://(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3}):(\\d+)",
             value)
         if m is None:
             self.error(object, name, value)

--- a/force_wfmanager/tests/test_run.py
+++ b/force_wfmanager/tests/test_run.py
@@ -16,6 +16,9 @@ class TestRun(unittest.TestCase):
         with mock.patch('force_wfmanager.gui.run.WfManager') as mock_wfmanager:
             mock_wfmanager.side_effect = mock_wfmanager_constructor
 
-            main(workflow_file=None, debug=False, window_size=(1680, 1050))
+            main(workflow_file=None,
+                 debug=False,
+                 profile=False,
+                 window_size=(1680, 1050))
 
             self.assertTrue(mock_wfmanager.called)

--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -123,8 +123,12 @@ class TestWfManager(GuiTestAssistant, unittest.TestCase):
 
     def test_switch_task(self):
         self.create_tasks()
-        self.assertEqual(self.wfmanager.windows[0].active_task,
-                         self.setup_task)
+        self.assertEqual(
+            self.wfmanager.windows[0].active_task,
+            self.setup_task,
+            msg='Note: this test can fail locally if a saved application '
+                'memento exists with the results task in focus'
+        )
         self.wfmanager.windows[0].active_task.switch_task()
         self.assertEqual(self.wfmanager.windows[0].active_task,
                          self.results_task)

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -326,8 +326,9 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
                 old_workflow,
                 self.setup_task.workflow_model)
             self.assertNotEqual(
-               old_workflow,
-               self.setup_task.side_pane.workflow_tree.model)
+                old_workflow,
+                self.setup_task.side_pane.workflow_tree.model
+            )
 
     def test_read_failure(self):
         mock_open = mock.mock_open()
@@ -524,7 +525,7 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
                     (OSError("whatever"), "whatever")]:
                 self.assertTrue(
                     _check_exception_behavior(exc).startswith(
-                        "Execution of BDSS failed. \n\n"+msg))
+                        "Execution of BDSS failed. \n\n" + msg))
 
     def test_run_bdss_write_failure(self):
         with mock.patch(WORKFLOW_WRITER_PATH) as mock_writer, \


### PR DESCRIPTION
This PR fixes #254 by switching the results view from TableEditor to a TabularEditor. This had a few side effects, as listed below:

- A fix to TraitsUI was required enthought/traitsui#521 which has since been merged to master, and thus this PR pins the TraitsUI version required by this package to that particular commit, to be switched back in the future (see #258)
- By switching to TabularEditor, you can now select multiples rows or multiple points on the plot to be highlighted.
- The plotting style was modified slightly to accommodate multiple selections.
- One other minor change is that the Force logo now rescales depending on the window size, rather than enforcing a minimum width ~500 pixels.
- Added --profile flag to force_wfmanager entrypoint that provides .prof/.pstats files.