### PR TITLE
Added colour mapped scatter plots

### DIFF
--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -8,8 +8,8 @@ from chaco.tools.api import PanTool, ScatterInspector, ZoomTool
 from enable.api import Component, ComponentEditor
 from enable.api import KeySpec
 from traits.api import (
-    Button, Bool, Enum, HasStrictTraits, Instance, List, Property, Tuple,
-    on_trait_change, Dict,
+    Button, Bool, Dict, Enum, HasStrictTraits, Instance, List, Property, Tuple,
+    on_trait_change
 )
 from traitsui.api import HGroup, Item, UItem, VGroup, View
 

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -145,13 +145,14 @@ class Plot(HasStrictTraits):
 
         self.update_data_arrays()
 
+    # Disable discrete color maps for now
     @on_trait_change('colormap_type')
     def update_colormap_list(self):
-        if self.colormap_type == 'Discrete':
-            self._available_colormaps = self.__discrete_colormaps
-            self._available_colormaps_names = self.__discrete_colormaps_names
-        else:
-            self._available_colormaps_names = self.__continuous_colormaps_names
+        # if self.colormap_type == 'Discrete':
+            # self._available_colormaps = self.__discrete_colormaps
+            # self._available_colormaps_names = self.__discrete_colormaps_names
+        # else:
+        self._available_colormaps_names = self.__continuous_colormaps_names
 
     def __plot_default(self):
         self._plot = self.plot_scatter()
@@ -215,12 +216,9 @@ class Plot(HasStrictTraits):
     @on_trait_change('colormap')
     def _update_cmap(self):
         cmap = self._available_colormaps[self.colormap]
-        try:
-            if isinstance(self._axis, ColormappedScatterPlot):
-                _range = self._axis.color_mapper.range
-                self._axis.color_mapper = cmap(_range)
-        except Exception as e:
-            print(e)
+        if isinstance(self._axis, ColormappedScatterPlot):
+            _range = self._axis.color_mapper.range
+            self._axis.color_mapper = cmap(_range)
 
     def plot_cmap_scatter(self):
         plot = ChacoPlot(self._plot_data)

--- a/force_wfmanager/central_pane/plot.py
+++ b/force_wfmanager/central_pane/plot.py
@@ -2,7 +2,7 @@ from chaco.api import ArrayPlotData, ArrayDataSource, ScatterInspectorOverlay
 from chaco.api import Plot as ChacoPlot
 from chaco.api import BaseXYPlot, ColormappedScatterPlot
 from chaco.default_colormaps import (
-    color_map_functions, discrete_color_map_functions
+    color_map_functions
 )
 from chaco.tools.api import PanTool, ScatterInspector, ZoomTool
 from enable.api import Component, ComponentEditor
@@ -41,11 +41,6 @@ class Plot(HasStrictTraits):
     #: Colour options button:
     color_options = Button('Color...')
 
-    #: Optional choice of colormap
-    colormap_type = Enum(
-        'Continuous',
-        # , 'Discrete') # disable discrete cmaps for now
-    )
     colormap = Enum(values='_available_colormaps_names',
                     depends_on='_available_colormaps_names')
 
@@ -63,26 +58,18 @@ class Plot(HasStrictTraits):
     #: Listens to: :attr:`x`, :attr:`y`
     _plot = Instance(Component)
 
-    #: Possible colormaps given color_map type
-    #: Listens to :attr:`colormap_type` and relies on default being the
+    #: List of continuous chaco colormaps.
     #: The default is set by the first entry of this list.
     __continuous_colormaps = Dict(
         {cmap.__str__().split()[1]: cmap
          for cmap in color_map_functions}
     )
-    __discrete_colormaps = Dict(
-        {cmap.__str__().split()[1]: cmap
-         for cmap in discrete_color_map_functions}
-    )
+    #: List of the names of continuous chaco colormaps.
     __continuous_colormaps_names = (
         ['viridis'] +
         [cmap.__str__().split()[1]
          for cmap in color_map_functions
          if cmap.__str__().split()[1] != 'viridis']
-    )
-    __discrete_colormaps_names = (
-        [cmap.__str__().split()[1]
-         for cmap in discrete_color_map_functions]
     )
 
     _available_colormaps = __continuous_colormaps
@@ -138,21 +125,6 @@ class Plot(HasStrictTraits):
             )
         )
     )
-
-    def __init__(self, analysis_model, *args, **kwargs):
-        self.analysis_model = analysis_model
-        super(Plot, self).__init__(*args, **kwargs)
-
-        self.update_data_arrays()
-
-    # Disable discrete color maps for now
-    @on_trait_change('colormap_type')
-    def update_colormap_list(self):
-        # if self.colormap_type == 'Discrete':
-            # self._available_colormaps = self.__discrete_colormaps
-            # self._available_colormaps_names = self.__discrete_colormaps_names
-        # else:
-        self._available_colormaps_names = self.__continuous_colormaps_names
 
     def __plot_default(self):
         self._plot = self.plot_scatter()
@@ -407,7 +379,6 @@ class Plot(HasStrictTraits):
         view = View(
             Item('color_plot'),
             Item('color_by', enabled_when='color_plot'),
-            Item('colormap_type', enabled_when='color_plot'),
             Item('colormap', enabled_when='color_plot'),
             kind='livemodal'
         )

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -74,6 +74,9 @@ class TestPlot(unittest.TestCase):
         self.plot.colormap = 'viridis'
         self.plot.colormap = 'CoolWarm'
 
+        self.plot.color_plot = False
+        self.assertIsInstance(self.plot._axis, ScatterPlot)
+
     def test_push_new_evaluation_steps(self):
         self.analysis_model.value_names = ('density', 'pressure')
         self.analysis_model.add_evaluation_step((1.010, 101325))

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -62,10 +62,6 @@ class TestPlot(unittest.TestCase):
         self.plot.colormap_type = 'Continuous'
         self.plot.colormap = viridis
 
-        self.assertEqual(self.plot._axis.colormapper, viridis)
-
-
-
     def test_push_new_evaluation_steps(self):
         self.analysis_model.value_names = ('density', 'pressure')
         self.analysis_model.add_evaluation_step((1.010, 101325))

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -65,12 +65,8 @@ class TestPlot(unittest.TestCase):
                              self.plot._axis.color_mapper.range)
 
         with self.assertRaises(TraitError):
-            self.plot.colormap_type = 'Discrete'
-
-        with self.assertRaises(TraitError):
             self.plot.colormap = 'not_viridis'
 
-        self.plot.colormap_type = 'Continuous'
         self.plot.colormap = 'viridis'
         self.plot.colormap = 'CoolWarm'
 

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -3,7 +3,6 @@ import warnings
 
 from chaco.api import Plot as ChacoPlot
 from chaco.api import ColormappedScatterPlot, ScatterPlot
-from chaco.api import viridis
 from chaco.abstract_colormap import AbstractColormap
 
 from force_wfmanager.central_pane.analysis_model import AnalysisModel
@@ -55,12 +54,15 @@ class TestPlot(unittest.TestCase):
             self.assertEqual(self.plot.color_by, 'color')
             self.assertIsInstance(self.plot._plot, ChacoPlot)
             self.assertIsInstance(self.plot._axis, ColormappedScatterPlot)
-            self.assertIsInstance(self.plot._axis.color_mapper, AbstractColormap)
+            self.assertIsInstance(self.plot._axis.color_mapper,
+                                  AbstractColormap)
             old_cmap = self.plot._axis.color_mapper
             self.plot.colormap = 'seismic'
-            self.assertIsInstance(self.plot._axis.color_mapper, AbstractColormap)
+            self.assertIsInstance(self.plot._axis.color_mapper,
+                                  AbstractColormap)
             self.assertNotEqual(old_cmap, self.plot._axis.color_mapper)
-            self.assertEqual(old_cmap.range, self.plot._axis.color_mapper.range)
+            self.assertEqual(old_cmap.range,
+                             self.plot._axis.color_mapper.range)
 
         with self.assertRaises(TraitError):
             self.plot.colormap_type = 'Discrete'

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -2,10 +2,12 @@ import unittest
 import warnings
 
 from chaco.api import Plot as ChacoPlot
+from chaco.api import ColormappedScatterPlot, ScatterPlot
+from chaco.api import viridis
 
 from force_wfmanager.central_pane.analysis_model import AnalysisModel
 from force_wfmanager.central_pane.plot import Plot
-from traits.api import push_exception_handler
+from traits.api import push_exception_handler, TraitError
 
 push_exception_handler(reraise_exceptions=True)
 
@@ -40,6 +42,29 @@ class TestPlot(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             self.assertIsInstance(self.plot._plot, ChacoPlot)
+            self.assertIsInstance(self.plot._axis, ScatterPlot)
+
+    def test_cmapped_plot(self):
+        self.analysis_model.value_names = ('density', 'pressure', 'color')
+        self.plot.color_plot = True
+        self.plot.color_by = 'color'
+        self.analysis_model.add_evaluation_step((1.010, 101325, 1))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.assertEqual(self.plot.color_by, 'color')
+            self.assertIsInstance(self.plot._plot, ChacoPlot)
+            self.assertIsInstance(self.plot._axis, ColormappedScatterPlot)
+
+        with self.assertRaises(TraitError):
+            self.plot.colormap_type = 'Discrete'
+            self.plot.colormap = viridis
+
+        self.plot.colormap_type = 'Continuous'
+        self.plot.colormap = viridis
+
+        self.assertEqual(self.plot._axis.colormapper, viridis)
+
+
 
     def test_push_new_evaluation_steps(self):
         self.analysis_model.value_names = ('density', 'pressure')

--- a/force_wfmanager/central_pane/tests/test_plot.py
+++ b/force_wfmanager/central_pane/tests/test_plot.py
@@ -4,6 +4,7 @@ import warnings
 from chaco.api import Plot as ChacoPlot
 from chaco.api import ColormappedScatterPlot, ScatterPlot
 from chaco.api import viridis
+from chaco.abstract_colormap import AbstractColormap
 
 from force_wfmanager.central_pane.analysis_model import AnalysisModel
 from force_wfmanager.central_pane.plot import Plot
@@ -54,13 +55,22 @@ class TestPlot(unittest.TestCase):
             self.assertEqual(self.plot.color_by, 'color')
             self.assertIsInstance(self.plot._plot, ChacoPlot)
             self.assertIsInstance(self.plot._axis, ColormappedScatterPlot)
+            self.assertIsInstance(self.plot._axis.color_mapper, AbstractColormap)
+            old_cmap = self.plot._axis.color_mapper
+            self.plot.colormap = 'seismic'
+            self.assertIsInstance(self.plot._axis.color_mapper, AbstractColormap)
+            self.assertNotEqual(old_cmap, self.plot._axis.color_mapper)
+            self.assertEqual(old_cmap.range, self.plot._axis.color_mapper.range)
 
         with self.assertRaises(TraitError):
             self.plot.colormap_type = 'Discrete'
-            self.plot.colormap = viridis
+
+        with self.assertRaises(TraitError):
+            self.plot.colormap = 'not_viridis'
 
         self.plot.colormap_type = 'Continuous'
-        self.plot.colormap = viridis
+        self.plot.colormap = 'viridis'
+        self.plot.colormap = 'CoolWarm'
 
     def test_push_new_evaluation_steps(self):
         self.analysis_model.value_names = ('density', 'pressure')


### PR DESCRIPTION
Adds option to colour points by a third column in results pane, with choice of continuous/discrete colourmaps.

Current issues:
- ~GUI displays cmaps selection as `<function $name #memaddr>`, rather than just the name.~
  - solved
- ~When switching colourmaps, the plot axes reset (losing e.g. any existing zoom/pan).~
  - solved
- ~Discrete colourmaps cause a crash when used with e.g. floating point data.~
  - disabled discrete colormaps for now