### PR TITLE
Minor interface fixes

### DIFF
--- a/force_wfmanager/left_side_pane/data_source_model_view.py
+++ b/force_wfmanager/left_side_pane/data_source_model_view.py
@@ -443,6 +443,13 @@ SLOT_DESCRIPTION = """
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+            .container{{
+                width: 100%;
+                font-family: sans-serif;
+                display: block;
+            }}
+        </style>
     </head>
     <body>
         <h2>{}</h2>
@@ -457,6 +464,13 @@ DEFAULT_MESSAGE = """
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+            .container{{
+                width: 100%;
+                font-family: sans-serif;
+                display: block;
+            }}
+        </style>
     </head>
     <body>
         <div class="container">

--- a/force_wfmanager/left_side_pane/new_entity_creator.py
+++ b/force_wfmanager/left_side_pane/new_entity_creator.py
@@ -270,17 +270,19 @@ class NewEntityCreator(HasStrictTraits):
         for model_attr_name in view_info:
             model_attr = self.model.trait(model_attr_name)
             model_attr_desc = model_attr.desc
+            model_attr_label = model_attr.label
+
+            if model_attr_label is not None:
+                name = model_attr_label
+            else:
+                name = model_attr_name.replace("_", " ").capitalize()
 
             if model_attr_desc is not None:
-                name_desc_pairs.append([model_attr_name, model_attr_desc])
+                name_desc_pairs.append([name, model_attr_desc])
             else:
                 name_desc_pairs.append([
-                    model_attr_name, "No description available."
+                    name, "No description available."
                 ])
-
-        # Format names as in the Instance Editor
-        name_desc_pairs = [[name.replace("_", " ").capitalize(), desc]
-                           for name, desc in name_desc_pairs]
 
         # Create a HTML string with all the model's parameters
         return htmlformat(model_name, model_desc, name_desc_pairs)
@@ -295,7 +297,11 @@ def htmlformat(factory_title=None, factory_description=None,
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
             <style type="text/css">
+                body{{
+                    font-family: sans-serif;
+                }}
                 .container{{
+                    font-family: sans-serif;
                     width: 100%;
                     display: block;
                 }}

--- a/force_wfmanager/left_side_pane/workflow_info.py
+++ b/force_wfmanager/left_side_pane/workflow_info.py
@@ -89,7 +89,8 @@ class WorkflowInfo(HasTraits):
     traits_view = View(
         VGroup(
             Group(
-                UReadonly('plugin_names', editor=ListStrEditor()),
+                UReadonly('plugin_names',
+                          editor=ListStrEditor(editable=False)),
                 show_border=True,
                 label='Available Plugins'
             ),

--- a/force_wfmanager/left_side_pane/workflow_info.py
+++ b/force_wfmanager/left_side_pane/workflow_info.py
@@ -174,6 +174,7 @@ ERROR_TEMPLATE = """
         <style type="text/css">
             .container{{
                 width: 100%;
+                font-family: sans-serif;
                 display: block;
             }}
         </style>

--- a/force_wfmanager/left_side_pane/workflow_tree.py
+++ b/force_wfmanager/left_side_pane/workflow_tree.py
@@ -752,6 +752,7 @@ ERROR_TEMPLATE = """
         <style type="text/css">
             .container{{
                 width: 100%;
+                font-family: sans-serif;
                 display: block;
             }}
         </style>

--- a/force_wfmanager/plugin_dialog.py
+++ b/force_wfmanager/plugin_dialog.py
@@ -110,8 +110,12 @@ def htmlformat(title, version=None, description=None, error_msg=None,
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
             <style type="text/css">
+                body{{
+                    font-family: sans-serif;
+                }}
                 .container{{
                     width: 100%;
+                    font-family: sans-serif;
                     display: block;
                 }}
             </style>


### PR DESCRIPTION
Some minor fixes to the wfmanager interface.

- Changes HTML font to sans-serif to match the rest of the GUI.
- Use trait `label` rather than `name` in model descriptions if defined.
- Fixes #261 by making plugin list uneditable.