### PR TITLE
Save and load results alongside the workflow that created them

### DIFF
--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -139,7 +139,7 @@ class AnalysisModel(HasStrictTraits):
 
         """
         json_representation = {}
-        for ind, name in enumerate(self.value_names):
+        for name in self.value_names:
             json_representation[name] = []
         for step in self.evaluation_steps:
             for ind, name in enumerate(self.value_names):

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -117,19 +117,17 @@ class AnalysisModel(HasStrictTraits):
         self._clear_evaluation_steps()
 
     def from_dict(self, data):
-        """ Load the :attr:`value_names` and :attr:`evaluation_steps`
-        from a dictionary.
+        """ Delete all current data and load :attr:`value_names` and
+        :attr:`evaluation_steps` from a dictionary.
 
         """
+        self._clear_evaluation_steps()
         self.value_names = tuple(key for key in data.keys())
-        steps = []
-        for ind, values in enumerate(data[self.value_names[0]]):
+        for ind, _ in enumerate(data[self.value_names[0]]):
             step = []
             for column in self.value_names:
                 step.append(data[column][ind])
-            steps.append(step)
-
-        self._evaluation_steps = steps
+            self.add_evaluation_step(step)
 
     def as_json(self):
         """ Returns a JSON representation with column names as keys and
@@ -193,4 +191,5 @@ class AnalysisModel(HasStrictTraits):
             # e.g. specify a floating point precision
             fp.write(', '.join([str(val) for val in step]) + '\n')
 
+        return True
         return True

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -1,3 +1,4 @@
+import json
 from traits.api import (
     Either, HasStrictTraits, Int, List, Property, Tuple, on_trait_change
 )
@@ -103,3 +104,49 @@ class AnalysisModel(HasStrictTraits):
         :attr:`value_names`
         """
         self._clear_evaluation_steps()
+
+    def write_to_json(self, fp):
+        """ Write the current state of the AnalysisModel to a file in JSON format.
+
+        Parameters
+        ----------
+        fp (a .write() supporting file-like object).
+
+        Returns
+        -------
+        bool: whether the write was successful or not.
+
+        """
+        json_representation = {}
+        for ind, name in enumerate(self.value_names):
+            json_representation[name] = []
+        for step in self.evaluation_steps:
+            for ind, name in enumerate(self.value_names):
+                json_representation[name].append(step[ind])
+        json.dump(json_representation,
+                  fp,
+                  sort_keys=False,
+                  indent=4)
+
+        return True
+
+    def write_to_csv(self, fp):
+        """ Write the current state of the AnalysisModel to a file in a CSV format,
+        that includes column names in the first line.
+
+        Parameters
+        ----------
+        fp (a .write() supporting file-like object).
+
+        Returns
+        -------
+        bool: whether the write was successful or not.
+
+        """
+        fp.write(', '.join(self.value_names) + '\n')
+        for step in self.evaluation_steps:
+            # val can have arbitrary type, so cannot
+            # e.g. specify a floating point precision
+            fp.write(', '.join([str(val) for val in step]) + '\n')
+
+        return True

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -192,4 +192,3 @@ class AnalysisModel(HasStrictTraits):
             fp.write(', '.join([str(val) for val in step]) + '\n')
 
         return True
-        return True

--- a/force_wfmanager/central_pane/analysis_model.py
+++ b/force_wfmanager/central_pane/analysis_model.py
@@ -1,6 +1,6 @@
 import json
 from traits.api import (
-    Either, HasStrictTraits, Int, List, Property, Tuple, on_trait_change
+    Bool, Either, HasStrictTraits, Int, List, Property, Tuple, on_trait_change
 )
 
 
@@ -22,6 +22,9 @@ class AnalysisModel(HasStrictTraits):
     #: Selected step, used for highlighting in the table/plot.
     #: Listens to: :attr:`value_names`
     _selected_step_indices = Either(None, List(Int()))
+
+    #: Tracks whether the current state of AnalysisModel can be saved to file
+    save_enabled = Bool(False)
 
     # ----------
     # Properties
@@ -45,6 +48,7 @@ class AnalysisModel(HasStrictTraits):
     def _clear_evaluation_steps(self):
         self._evaluation_steps[:] = []
         self._selected_step_indices = None
+        self.save_enabled = False
 
     def _get_evaluation_steps(self):
         return self._evaluation_steps
@@ -68,6 +72,7 @@ class AnalysisModel(HasStrictTraits):
                     evaluation_step, self.value_names))
 
         self._evaluation_steps.append(evaluation_step)
+        self.save_enabled = True
 
     def _get_selected_step_indices(self):
         return self._selected_step_indices
@@ -117,6 +122,9 @@ class AnalysisModel(HasStrictTraits):
         bool: whether the write was successful or not.
 
         """
+        if not self._save_enabled:
+            return False
+
         json_representation = {}
         for ind, name in enumerate(self.value_names):
             json_representation[name] = []
@@ -143,6 +151,9 @@ class AnalysisModel(HasStrictTraits):
         bool: whether the write was successful or not.
 
         """
+        if not self._save_enabled:
+            return False
+
         fp.write(', '.join(self.value_names) + '\n')
         for step in self.evaluation_steps:
             # val can have arbitrary type, so cannot

--- a/force_wfmanager/central_pane/tests/test_analysis_model.py
+++ b/force_wfmanager/central_pane/tests/test_analysis_model.py
@@ -1,5 +1,4 @@
 import unittest
-import json
 from unittest import mock
 
 from traits.trait_errors import TraitError

--- a/force_wfmanager/central_pane/tests/test_analysis_model.py
+++ b/force_wfmanager/central_pane/tests/test_analysis_model.py
@@ -1,4 +1,6 @@
 import unittest
+import json
+from unittest import mock
 
 from traits.trait_errors import TraitError
 
@@ -82,3 +84,67 @@ class TestAnalysisModel(unittest.TestCase):
         self.assertEqual(self.analysis.value_names, ())
         self.assertEqual(self.analysis.evaluation_steps, [])
         self.assertEqual(self.analysis.selected_step_indices, None)
+
+    def test_as_json(self):
+        self.analysis.value_names = ('foo', 'bar', 'label')
+        self.analysis.add_evaluation_step((1, 2, 'x'))
+        self.analysis.add_evaluation_step((3, 4, 'y'))
+        self.analysis.add_evaluation_step((5, 6, 'z'))
+        json_rep = {'foo': [1, 3, 5],
+                    'bar': [2, 4, 6],
+                    'label': ['x', 'y', 'z']}
+
+        self.assertEqual(self.analysis.as_json(), json_rep)
+
+    def test_from_dict(self):
+        json_rep = {'foo': [1, 3, 5],
+                    'bar': [2, 4, 6],
+                    'label': ['x', 'y', 'z']}
+        self.analysis.value_names = ('notfoo', 'notbar', 'notlabel')
+
+        self.analysis.add_evaluation_step((11, 22, 'xx'))
+        self.analysis.add_evaluation_step((55, 66, 'zz'))
+
+        self.analysis.from_dict(json_rep)
+        self.assertEqual(self.analysis.value_names, ('foo', 'bar', 'label'))
+        self.assertEqual(len(self.analysis.evaluation_steps), 3)
+        self.assertEqual(self.analysis.evaluation_steps[0], (1, 2, 'x'))
+        self.assertEqual(self.analysis.evaluation_steps[1], (3, 4, 'y'))
+        self.assertEqual(self.analysis.evaluation_steps[2], (5, 6, 'z'))
+
+    def test_write_to_json(self):
+        json_rep = {'foo': [1, 3, 5],
+                    'bar': [2, 4, 6],
+                    'label': ['x', 'y', 'z']}
+        self.analysis.from_dict(json_rep)
+        self.assertEqual(self.analysis.as_json(), json_rep)
+        mock_open = mock.mock_open()
+        with mock.patch('__main__.open', mock_open, create=True):
+            with mock_open('blah', 'w') as fp:
+                success = self.analysis.write_to_json(fp)
+
+        self.assertTrue(success)
+
+    def test_write_to_csv(self):
+        json_rep = {'foo': [1, 3, 5],
+                    'bar': [2, 4, 6],
+                    'label': ['x', 'y', 'z']}
+        self.analysis.from_dict(json_rep)
+        self.assertEqual(self.analysis.as_json(), json_rep)
+        mock_open = mock.mock_open()
+        with mock.patch('__main__.open', mock_open, create=True):
+            with mock_open('blah', 'w') as fp:
+                success = self.analysis.write_to_csv(fp)
+
+        self.assertTrue(success)
+        handle = mock_open()
+
+        csv_string = ['foo, bar, label\n',
+                      '1, 2, x\n',
+                      '3, 4, y\n',
+                      '5, 6, z\n']
+
+        # unfortunately this doesn't enforce the order of the call
+        # but I think this is probably overkill anyway...
+        for line in csv_string:
+            handle.write.assert_any_call(line)

--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -104,7 +104,7 @@ class TestWfManager(GuiTestAssistant, unittest.TestCase):
         self.assertIsInstance(self.setup_task.workflow_model, Workflow)
 
         self.assertIsInstance(self.results_task.analysis_model, AnalysisModel)
-        self.assertIsInstance(self.results_task.workflow_model, Workflow)
+        self.assertEqual(self.results_task.workflow_model, None)
 
     def test_init_with_file(self):
         with mock.patch(WORKFLOW_READER_PATH) as mock_reader:

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -46,7 +46,8 @@ ZMQSERVER_SETUP_SOCKETS_PATH = \
 RESULTS_FILE_DIALOG_PATH = 'force_wfmanager.wfmanager_results_task.FileDialog'
 RESULTS_FILE_OPEN_PATH = 'force_wfmanager.wfmanager_results_task.open'
 RESULTS_JSON_DUMP_PATH = 'force_wfmanager.wfmanager_results_task.json.dump'
-RESULTS_WORKFLOW_WRITER_PATH = 'force_wfmanager.wfmanager_results_task.WorkflowWriter.get_workflow_data'
+RESULTS_WORKFLOW_WRITER_PATH = \
+    'force_wfmanager.wfmanager_results_task.WorkflowWriter.get_workflow_data'
 
 
 def mock_dialog(dialog_class, result, path=''):
@@ -517,19 +518,19 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
                 mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer, \
-                mock.patch(SUBPROCESS_PATH + ".check_call") as mock_check_call, \
+                mock.patch(SUBPROCESS_PATH + ".check_call") as mock_chk_call, \
                 mock.patch(ERROR_PATH) as mock_error:
             mock_dialog.side_effect = mock_dialog(FileDialog, OK)
             mock_writer.side_effect = mock_file_writer
             mock_error.side_effect = mock_show_error
 
             def _check_exception_behavior(exception):
-                mock_check_call.side_effect = exception
+                mock_chk_call.side_effect = exception
 
                 self.assertTrue(self.setup_task.side_pane.ui_enabled)
 
                 with self.event_loop_until_condition(
-                        lambda: mock_check_call.called):
+                        lambda: mock_chk_call.called):
                     self.setup_task.run_bdss()
 
                 ui_enabled = self.setup_task.side_pane.ui_enabled

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -43,6 +43,10 @@ SUBPROCESS_PATH = 'force_wfmanager.wfmanager_setup_task.subprocess'
 OS_REMOVE_PATH = 'force_wfmanager.wfmanager_setup_task.os.remove'
 ZMQSERVER_SETUP_SOCKETS_PATH = \
     'force_wfmanager.wfmanager_setup_task.ZMQServer._setup_sockets'
+RESULTS_FILE_DIALOG_PATH = 'force_wfmanager.wfmanager_results_task.FileDialog'
+RESULTS_FILE_OPEN_PATH = 'force_wfmanager.wfmanager_results_task.open'
+RESULTS_JSON_DUMP_PATH = 'force_wfmanager.wfmanager_results_task.json.dump'
+RESULTS_WORKFLOW_WRITER_PATH = 'force_wfmanager.wfmanager_results_task.WorkflowWriter.get_workflow_data'
 
 
 def mock_dialog(dialog_class, result, path=''):
@@ -230,6 +234,23 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
             self.assertTrue(mock_writer.called)
             self.assertTrue(mock_open.called)
             self.assertFalse(mock_file_dialog.called)
+
+    def test_save_project(self):
+        mock_open = mock.mock_open()
+        with mock.patch(RESULTS_FILE_DIALOG_PATH) as mock_file_dialog, \
+                mock.patch(RESULTS_JSON_DUMP_PATH) as mock_json_dump, \
+                mock.patch(RESULTS_FILE_OPEN_PATH, mock_open, create=True), \
+                mock.patch(RESULTS_WORKFLOW_WRITER_PATH) as mock_wf_writer:
+            mock_file_dialog.side_effect = mock_dialog(
+                FileDialog, OK, 'file_path')
+            mock_wf_writer.side_effect = mock_file_writer
+
+            self.results_task.save_project_as()
+
+            self.assertTrue(mock_wf_writer.called)
+            self.assertTrue(mock_open.called)
+            self.assertTrue(mock_json_dump.called)
+            self.assertTrue(mock_file_dialog.called)
 
     def test_save_workflow_failure(self):
         mock_open = mock.mock_open()
@@ -496,7 +517,7 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
         with mock.patch(FILE_DIALOG_PATH) as mock_dialog, \
                 mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(WORKFLOW_WRITER_PATH) as mock_writer, \
-                mock.patch(SUBPROCESS_PATH+".check_call") as mock_check_call, \
+                mock.patch(SUBPROCESS_PATH + ".check_call") as mock_check_call, \
                 mock.patch(ERROR_PATH) as mock_error:
             mock_dialog.side_effect = mock_dialog(FileDialog, OK)
             mock_writer.side_effect = mock_file_writer

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -50,6 +50,8 @@ RESULTS_JSON_DUMP_PATH = 'force_wfmanager.wfmanager_results_task.json.dump'
 RESULTS_JSON_LOAD_PATH = 'force_wfmanager.wfmanager_results_task.json.load'
 RESULTS_WORKFLOW_WRITER_PATH = \
     'force_wfmanager.wfmanager_results_task.WorkflowWriter.get_workflow_data'
+RESULTS_WORKFLOW_READER_PATH = \
+    'force_wfmanager.wfmanager_results_task.WorkflowReader'
 RESULTS_ERROR_PATH = 'force_wfmanager.wfmanager_results_task.error'
 
 
@@ -379,7 +381,7 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
                 mock.patch(RESULTS_JSON_LOAD_PATH) as mock_json, \
                 mock.patch(FILE_OPEN_PATH, mock_open, create=True), \
                 mock.patch(RESULTS_FILE_OPEN_PATH, mock_open, create=True), \
-                mock.patch(WORKFLOW_READER_PATH) as mock_reader:
+                mock.patch(RESULTS_WORKFLOW_READER_PATH) as mock_reader:
             mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
             mock_reader.side_effect = mock_file_reader
             mock_json.return_value = {'analysis_model': {'x': [1], 'y': [2]},
@@ -401,6 +403,9 @@ class TestWFManagerTasks(GuiTestAssistant, unittest.TestCase):
             self.assertTrue(mock_json.called)
 
             self.assertNotEqual(old_workflow, self.results_task.workflow_model)
+            self.assertNotEqual(self.setup_task.workflow_model,
+                                self.results_task.workflow_model)
+
             self.assertNotEqual(old_workflow, self.setup_task.workflow_model)
             self.assertNotEqual(old_workflow,
                                 self.setup_task.side_pane.workflow_tree.model)

--- a/force_wfmanager/wfmanager_results_task.py
+++ b/force_wfmanager/wfmanager_results_task.py
@@ -45,7 +45,7 @@ class WfManagerResultsTask(Task):
     save_load_enabled = Bool(True)
 
     #: Is the results saving button enabled?
-    save_results_enabled = Bool(True)
+    save_results_enabled = Bool(False)
 
     #: Setup Task
     setup_task = Instance(Task)
@@ -199,7 +199,12 @@ class WfManagerResultsTask(Task):
     def _analysis_model_default(self):
         return AnalysisModel()
 
-    # Save AnalysisModel to JSON file
+    # Save AnalysisModel to file and sync its state
+
+    @on_trait_change('analysis_model.save_enabled')
+    def sync_save_enabled(self):
+        self.save_results_enabled = self.analysis_model.save_enabled
+
     def save_analysis_model_as(self):
         """ Shows a dialog to save the analysis model into a JSON file """
         dialog = FileDialog(
@@ -252,7 +257,6 @@ class WfManagerResultsTask(Task):
             return False
         else:
             return True
-
 
     # Synchronization with Setup Task
 

--- a/force_wfmanager/wfmanager_results_task.py
+++ b/force_wfmanager/wfmanager_results_task.py
@@ -427,10 +427,15 @@ class WfManagerResultsTask(Task):
                 if task.name == "Workflow Setup":
                     self.setup_task = task
                     self.analysis_model = self.setup_task.analysis_model
-                    # self.workflow_model = self.setup_task.workflow_model
 
     @on_trait_change('setup_task.computation_running')
     def cache_running_workflow(self):
+        """ When a new computation starts running, save a copy of the
+        :attr:`setup_task.workflow_model` as :attr:workflow_model` that
+        can be used when saving the results of the run alongside the
+        workflow that created it.
+
+        """
         if self.setup_task.computation_running:
             with tempfile.TemporaryFile(mode='w+t') as fp:
                 WorkflowWriter().write(self.setup_task.workflow_model, fp)

--- a/force_wfmanager/wfmanager_results_task.py
+++ b/force_wfmanager/wfmanager_results_task.py
@@ -253,15 +253,14 @@ class WfManagerResultsTask(Task):
         """
         try:
             with open(file_path, 'w') as output:
+                # create a dictionary that contains analysis model,
+                # workflow and version that can be read back in by
+                # :class:`WorkflowReader`, and dump to JSON
                 project_json = {}
                 project_json['analysis_model'] = self.analysis_model.as_json()
                 project_json['workflow'] = WorkflowWriter() \
                     .get_workflow_data(self.workflow_model)
-                try:
-                    project_json['version'] = WorkflowWriter().version
-                except AttributeError:
-                    project_json['version'] = '1'
-
+                project_json['version'] = WorkflowWriter().version
                 json.dump(project_json, output, indent=4)
 
         except IOError as e:


### PR DESCRIPTION
Closes #266 .

This PR adds the following functionality to the workflow manager and its GUI:

- Export analysis model (i.e. table of results) to JSON or CSV, for use elsewhere.
- Save "Project" files containing the analysis model *and* the workflow used to generate it.
    - This required a change to the results task such that it takes a copy of the workflow when it has been run, and does not update with the setup task's copy.
- Open project files from the results view, loading the correct state into both results and setup task, displaying the results in the default view.
