### PR TITLE
Fixes for windows build

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -11,8 +11,8 @@ ADDITIONAL_CORE_DEPS = [
     "qt==4.8.7-7",
     "sip==4.17-4",
     "traitsui==6.0.0-2",
-    "numpy==1.13.3-3",
-    "chaco==4.7.1-2",
+    "numpy==1.15.4-2",
+    "chaco==4.7.2-3",
     "pyzmq==16.0.0-4",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     description='Workflow manager',
     long_description=README_TEXT,
     packages=find_packages(),
-    package_data={'force_wfmanager.left_side_pane': 'icons/*'},
+    package_data={'force_wfmanager.left_side_pane': ['*.png']},
     entry_points={
         'gui_scripts': [
             'force_wfmanager = force_wfmanager.gui.run:force_wfmanager'


### PR DESCRIPTION
There was an error in `setup.py` where `package_data` was given as a string rather than a list of strings. This was fine on unix but I guess on windows it tries to do some path conversion and fails there.
Also upgraded numpy & chaco since we need them for plugins using scipy (which is most of them!)