### PR TITLE
BUG: included mock in dependencies for GuiTestAssistant in pyface

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -14,6 +14,7 @@ ADDITIONAL_CORE_DEPS = [
     "numpy==1.13.3-3",
     "chaco==4.7.1-2",
     "pyzmq==16.0.0-4",
+    "mock==2.0.0-1"
 ]
 
 # Pick particular TraitsUI commit until TabularEditor fixes are merged.


### PR DESCRIPTION
Dependency on 3rd party `mock` was removed in https://github.com/force-h2020/force-bdss/pull/219

However, `pyface==6.0.0-2` `GuiTestAssistant` class still imports it explicitly, which is used in several test wfmanager test functions.

In future it would be great to use `pyface>=6.1.0`, which includes replacing `mock` with `unittest.mock`, though this also requires unpinning other libraries (`traitsui`, `chaco` etc...)

For now, `mock==2.0.0-1` is put back in as a dependency to the wf_manager `ci.__main__.py`