### PR TITLE
Fix: test filename in OS-independent way

### DIFF
--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import unittest.mock as mock
 
@@ -111,7 +112,7 @@ class TestWfManager(GuiTestAssistant, unittest.TestCase):
             mock_reader.side_effect = mock_file_reader
             self.wfmanager = dummy_wfmanager(fixtures.get('evaluation-4.json'))
             self.create_tasks()
-            self.assertEqual(self.setup_task.current_file.split('/')[-1],
+            self.assertEqual(os.path.basename(self.setup_task.current_file),
                              'evaluation-4.json')
             self.assertEqual(mock_reader.call_count, 1)
 


### PR DESCRIPTION
Simple fix in a test.
Note: `current_file` is a File() trait.

With this addition, I have the whole test suite passing locally on Windows.

(The CI failure seems unrelated and affects all commits to master at the moment)