### PR TITLE
Fix: updated .travis.yml for XVFB handing on Ubuntu >= Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-language: c
+language: generic
 cache:
   directories:
       - "$HOME/.cache"
       - "$HOME/.ccache"
+dist: bionic
+services:
+    - xvfb
 before_install:
     - ccache -s
     - export PATH=/usr/lib/ccache:${PATH}
@@ -11,12 +14,12 @@ before_install:
     - edm install -y --version 3.5 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
+    - sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8
     - export ETS_TOOLKIT=qt4
     - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
     - edm run -- python -m ci test
     - edm run -- python -m ci docs
 after_success:


### PR DESCRIPTION
XVFB now not called directly on Travis CI for versions of Ubuntu >= 16.04 (Xenial), but instead introduced using `services`

https://slack-redir.net/link?url=https%3A%2F%2Fdocs.travis-ci.com%2Fuser%2Fgui-and-headless-browsers%2F

Workaround includes also explicitly installing `libglu` drivers to ensure that all test involving `qt` run.

Also set testing version of Ubuntu as Bionic, as this will be the system aimed for release.