### PR TITLE
Travis ci macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: generic
 sudo: false
 
+env:
+  global:
+    - EDM_FULL=1.11.0
+      EDM_X_Y=1.11
+
 matrix:
   include:
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,30 @@
 language: generic
-cache:
-  directories:
-      - "$HOME/.cache"
-      - "$HOME/.ccache"
-dist: bionic
-services:
-    - xvfb
+sudo: false
+
+matrix:
+  include:
+  - os: linux
+    dist: bionic
+    services:
+      - xvfb
+    env: 
+      - EDM_OS="rh5_x86_64"
+        EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
+  - os: osx
+    env:
+      - EDM_OS="osx_x86_64"
+        EDM_INSTALLER_SUFFIX=".pkg"
+
 before_install:
-    - ccache -s
-    - export PATH=/usr/lib/ccache:${PATH}
-    - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
-    - export PATH=${HOME}/edm/bin:${PATH}
-    - edm install -y --version 3.6 click setuptools
+    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
+    - edm install --version 3.6 -y click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
-    - sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8
@@ -23,5 +33,5 @@ script:
     - edm run -- python -m ci test
     - edm run -- python -m ci docs
 after_success:
-    - edm run -- python -m ci coverage
-    - bash <(curl -s https://codecov.io/bash)
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- python -m ci coverage; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
This PR:
- adds a macOS CI job
- makes other updates to CI VM (`generic` instead of `c`, no `ccache`) and edm setup (newest edm, Python 3.6 for bootstrap).

Similar to https://github.com/force-h2020/force-bdss/pull/223