### PR TITLE
Refactor of Property traits' getters to reduce redundant communication

### DIFF
--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -171,7 +171,7 @@ class Plot(HasStrictTraits):
             marker_size=4,
             bgcolor="white")[0]
 
-        plot.set(title="Plot", padding=75, line_width=1)
+        plot.trait_set(title="Plot", padding=75, line_width=1)
 
         # Add pan and zoom tools
         scatter_plot.tools.append(PanTool(plot))
@@ -179,8 +179,8 @@ class Plot(HasStrictTraits):
 
         # Set the scatterplot's default selection marker invisible as it
         # lead to artifacts on axis when switching between plotted cols
-        scatter_plot.set(selection_color=(0, 0, 0, 0),
-                         selection_outline_color=(0, 0, 0, 0))
+        scatter_plot.trait_set(selection_color=(0, 0, 0, 0),
+                               selection_outline_color=(0, 0, 0, 0))
 
         # Add the selection tool
         inspector, overlay = self._get_scatter_inspector_overlay(
@@ -217,7 +217,7 @@ class Plot(HasStrictTraits):
             line_width=0,
             bgcolor="white")[0]
 
-        plot.set(title="Plot", padding=75, line_width=1)
+        plot.trait_set(title="Plot", padding=75, line_width=1)
 
         # Add pan and zoom tools
         cmap_scatter_plot.tools.append(PanTool(plot))

--- a/force_wfmanager/ui/setup/execution_layers/data_source_model_view.py
+++ b/force_wfmanager/ui/setup/execution_layers/data_source_model_view.py
@@ -339,9 +339,7 @@ class DataSourceModelView(ModelView):
         slot is changed"""
         self.verify_workflow_event = True
 
-    @on_trait_change(
-        'model.+'
-    )
+    @on_trait_change('model.+')
     def data_source_model_change(self):
         """Fires :func:`verify_workflow_event` when any trait on the
         data source model is changed"""
@@ -431,6 +429,7 @@ class DataSourceModelView(ModelView):
     # Description update on UI selection change
 
     def _get_selected_slot_description(self):
+        print('selected_slot_description called')
         if self.selected_slot_row is None:
             return DEFAULT_MESSAGE
 

--- a/force_wfmanager/ui/setup/execution_layers/data_source_model_view.py
+++ b/force_wfmanager/ui/setup/execution_layers/data_source_model_view.py
@@ -429,7 +429,6 @@ class DataSourceModelView(ModelView):
     # Description update on UI selection change
 
     def _get_selected_slot_description(self):
-        print('selected_slot_description called')
         if self.selected_slot_row is None:
             return DEFAULT_MESSAGE
 

--- a/force_wfmanager/ui/setup/execution_layers/data_source_model_view.py
+++ b/force_wfmanager/ui/setup/execution_layers/data_source_model_view.py
@@ -232,6 +232,11 @@ class DataSourceModelView(ModelView):
     )
 
     def __init__(self, model, variable_names_registry, *args, **kwargs):
+        #: FIXME need to make sure default model traits_view was been called
+        # at least once otherwise error checking of any trait in model
+        # does not work
+        model.trait_view()
+
         self.model = model
         self.variable_names_registry = variable_names_registry
 
@@ -332,6 +337,14 @@ class DataSourceModelView(ModelView):
     def data_source_change(self):
         """Fires :func:`verify_workflow_event` when an input slot or output
         slot is changed"""
+        self.verify_workflow_event = True
+
+    @on_trait_change(
+        'model.+'
+    )
+    def data_source_model_change(self):
+        """Fires :func:`verify_workflow_event` when any trait on the
+        data source model is changed"""
         self.verify_workflow_event = True
 
     # Changed Slots Functions

--- a/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
@@ -1,5 +1,7 @@
 from traits.api import (
-    Instance, Unicode, Bool, on_trait_change, Event, Property)
+    Instance, Unicode, Bool, on_trait_change, Event, Property,
+    cached_property
+)
 from traitsui.api import View, Item, ModelView
 
 from force_bdss.api import BaseMCOParameter
@@ -58,7 +60,7 @@ class MCOParameterModelView(ModelView):
         self.verify_workflow_event = True
 
     # Properties
-
+    @cached_property
     def _get_label(self):
         if self.model.name == '' and self.model.type == '':
             return self._label_default()

--- a/force_wfmanager/ui/setup/new_entity_creator.py
+++ b/force_wfmanager/ui/setup/new_entity_creator.py
@@ -100,7 +100,7 @@ class NewEntityCreator(HasStrictTraits):
 
     #: A Bool which is True if model has a view with at least one user
     #: editable attribute, False otherwise.
-    _current_model_editable = Property(Bool, depends_on="model")
+    current_model_editable = Bool()
 
     def __init__(self, factories, *args, **kwargs):
         super(NewEntityCreator, self).__init__(*args, **kwargs)
@@ -140,12 +140,12 @@ class NewEntityCreator(HasStrictTraits):
                     VGroup(
                         UItem(
                             "model", style="custom", editor=InstanceEditor(),
-                            visible_when="_current_model_editable is True"
+                            visible_when="current_model_editable is True"
                               ),
                         UItem(
                             "_no_config_options_msg", style="readonly",
                             editor=HTMLEditor(),
-                            visible_when="_current_model_editable is False"
+                            visible_when="current_model_editable is False"
                         ),
                         visible_when="model is not None",
                         style="custom",
@@ -238,11 +238,12 @@ class NewEntityCreator(HasStrictTraits):
         plugin = factory.plugin
         return plugin
 
-    def _get__current_model_editable(self):
+    @on_trait_change('model')
+    def _get_current_model_editable(self):
         """A check which returns True if 1. A view with at least
         one item exists for this model and 2. Those items
         are actually visible to the user."""
-        return model_info(self.model) != []
+        self.current_model_editable = (model_info(self.model) != [])
 
     def _get_model_description_HTML(self):
         """Return a HTML formatted description of the currently selected

--- a/force_wfmanager/ui/setup/new_entity_creator.py
+++ b/force_wfmanager/ui/setup/new_entity_creator.py
@@ -1,6 +1,6 @@
 from traits.api import (
     Bool, Callable, Dict, Either, HasStrictTraits, Instance, List, ReadOnly,
-    Property, Unicode, on_trait_change
+    Property, Unicode, on_trait_change, cached_property
 )
 from traitsui.api import (
     HSplit, HTMLEditor, InstanceEditor, Menu, TreeEditor, TreeNode, UItem,
@@ -245,6 +245,7 @@ class NewEntityCreator(HasStrictTraits):
         are actually visible to the user."""
         self.current_model_editable = (model_info(self.model) != [])
 
+    @cached_property
     def _get_model_description_HTML(self):
         """Return a HTML formatted description of the currently selected
         model and its parameters. This is constructed from the currently

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -205,7 +205,6 @@ class SetupPane(TraitsTaskPane):
         return namespace
 
     # Property getters
-
     def _get_selected_mv_editable(self):
         """ Determines if the selected modelview in the WorkflowTree has a
         default or non-default view associated. A default view should not

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -58,7 +58,7 @@ class SetupPane(TraitsTaskPane):
     #: Listens to: :attr:`models.workflow_tree.selected_factory_name
     #: <force_wfmanager.models.workflow_tree.WorkflowTree.\
     #: selected_factory_name>`
-    selected_factory_name = Unicode('Workflow')
+    selected_factory_name = Unicode()
 
     #: A function which adds a new entity to the workflow tree, using the
     #: currently selected factory. For example, if the 'DataSources' factory
@@ -96,7 +96,7 @@ class SetupPane(TraitsTaskPane):
     #: displaying a default view when a model does not have a View defined for
     #: it. If a modelview has a View defining how it is represented in the UI
     #: then this is used.
-    selected_mv_editable = Property(Bool, depends_on='selected_mv')
+    selected_mv_editable = Bool()
 
     #: A panel displaying extra information about the workflow: Available
     #: Plugins, non-KPI variables, current filenames and any error messages.
@@ -205,7 +205,8 @@ class SetupPane(TraitsTaskPane):
         return namespace
 
     # Property getters
-    def _get_selected_mv_editable(self):
+    @on_trait_change('selected_mv')
+    def get_selected_mv_editable(self):
         """ Determines if the selected modelview in the WorkflowTree has a
         default or non-default view associated. A default view should not
         be editable by the user, a non-default one should be.
@@ -224,8 +225,9 @@ class SetupPane(TraitsTaskPane):
             currently selected
         """
         if self.selected_mv is None or self.selected_mv.trait_views() == []:
-            return False
-        return True
+            self.selected_mv_editable = False
+        else:
+            self.selected_mv_editable = True
 
     def _get_enable_add_button(self):
         """ Determines if the add button in the UI should be enabled.

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -299,6 +299,9 @@ class SetupPane(TraitsTaskPane):
         self.selected_mv = self.task.side_pane.workflow_tree.selected_mv
         if self.selected_mv is not None:
             if isinstance(self.selected_mv.model, BaseModel):
+                #: FIXME - this will raise an AttributeError if
+                #: self.selected_mv.model has not initialised a traits_view
+                #: object
                 self.selected_model = self.selected_mv.model
             else:
                 self.selected_model = None

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -268,7 +268,7 @@ class SetupPane(TraitsTaskPane):
         return WorkflowInfo(
             plugins=plugins, workflow_mv=workflow_mv,
             workflow_filename=self.task.current_file,
-            selected_factory=self.selected_factory_name
+            selected_factory_name=self.selected_factory_name
         )
 
     def _get_add_new_entity_label(self):

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -219,9 +219,24 @@ class SetupPane(TraitsTaskPane):
         """
         if self.selected_mv is None or self.selected_mv.trait_views() == []:
             self.selected_mv_editable = False
-        self.selected_mv_editable = True
+        else:
+            self.selected_mv_editable = True
 
-    @on_trait_change('entity_creator,entity_creator.model')
+    @on_trait_change('selected_mv')
+    def _get_selected_model(self):
+        """Checks if the model held by the modelview needs to be displayed
+        in the UI.
+        """
+        if self.selected_mv is not None:
+            if isinstance(self.selected_mv.model, BaseModel):
+                #: FIXME - this will raise an AttributeError if
+                #: self.selected_mv.model has not initialised a traits_view
+                #: object
+                self.selected_model = self.selected_mv.model
+            else:
+                self.selected_model = None
+
+    @on_trait_change('selected_factory_name,entity_creator,entity_creator.model')
     def _get_enable_add_button(self):
         """ Determines if the add button in the UI should be enabled.
 
@@ -274,6 +289,12 @@ class SetupPane(TraitsTaskPane):
 
     # Synchronisation with WorkflowTree
 
+    @on_trait_change('task.side_pane.workflow_tree.selected_mv')
+    def sync_selected_mv(self):
+        """ Synchronise selected_mv with the selected modelview in the tree
+        editor."""
+        self.selected_mv = self.task.side_pane.workflow_tree.selected_mv
+
     @on_trait_change('task.side_pane.workflow_tree.add_new_entity')
     def sync_add_new_entity(self):
         """Synchronises add_new_entity with WorkflowTree"""
@@ -288,21 +309,6 @@ class SetupPane(TraitsTaskPane):
             self.task.side_pane.workflow_tree.remove_entity
         )
 
-    @on_trait_change('task.side_pane.workflow_tree.selected_mv')
-    def sync_selected_mv(self):
-        """ Synchronise selected_mv with the selected modelview in the tree
-        editor. Checks if the model held by the modelview needs to be displayed
-        in the UI."""
-        self.selected_mv = self.task.side_pane.workflow_tree.selected_mv
-        if self.selected_mv is not None:
-            if isinstance(self.selected_mv.model, BaseModel):
-                #: FIXME - this will raise an AttributeError if
-                #: self.selected_mv.model has not initialised a traits_view
-                #: object
-                self.selected_model = self.selected_mv.model
-            else:
-                self.selected_model = None
-
     @on_trait_change('task.side_pane.workflow_tree.selected_factory_name')
     def sync_selected_factory_name(self):
         """Synchronises selected_factory_name with WorkflowTree"""
@@ -313,6 +319,7 @@ class SetupPane(TraitsTaskPane):
     @on_trait_change('task.side_pane.workflow_tree.entity_creator')
     def sync_entity_creator(self):
         """Synchronises entity_creator with WorkflowTree"""
+        print('sync_entity_creator called')
         self.entity_creator = self.task.side_pane.workflow_tree.entity_creator
 
     # Button event handlers for creating and deleting workflow items

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -1,6 +1,6 @@
 from pyface.tasks.api import TraitsTaskPane
 from traits.api import (
-    Bool, Button, Callable, Instance, Property, Unicode,
+    Bool, Button, Callable, Instance, Unicode,
     on_trait_change
 )
 from traitsui.api import (
@@ -236,7 +236,8 @@ class SetupPane(TraitsTaskPane):
             else:
                 self.selected_model = None
 
-    @on_trait_change('selected_factory_name,entity_creator,entity_creator.model')
+    @on_trait_change('selected_factory_name,entity_creator,'
+                     'entity_creator.model')
     def _get_enable_add_button(self):
         """ Determines if the add button in the UI should be enabled.
 
@@ -285,8 +286,9 @@ class SetupPane(TraitsTaskPane):
     @on_trait_change('selected_factory_name')
     def _get_add_new_entity_label(self):
         """Returns the label displayed on add_new_entity_btn"""
-        self.add_new_entity_label = 'Add New {!s}'.format(self.selected_factory_name)
-
+        self.add_new_entity_label = (
+                'Add New {!s}'.format(self.selected_factory_name)
+        )
     # Synchronisation with WorkflowTree
 
     @on_trait_change('task.side_pane.workflow_tree.selected_mv')
@@ -319,7 +321,6 @@ class SetupPane(TraitsTaskPane):
     @on_trait_change('task.side_pane.workflow_tree.entity_creator')
     def sync_entity_creator(self):
         """Synchronises entity_creator with WorkflowTree"""
-        print('sync_entity_creator called')
         self.entity_creator = self.task.side_pane.workflow_tree.entity_creator
 
     # Button event handlers for creating and deleting workflow items

--- a/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
+++ b/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
@@ -77,7 +77,7 @@ class TestNewEntityModal(unittest.TestCase):
 
         modal, modal_info = self._get_mco_selector()
 
-        self.assertFalse(modal._current_model_editable)
+        self.assertFalse(modal.current_model_editable)
 
         self.assertIn("No Model", modal.model_description_HTML)
 
@@ -119,7 +119,7 @@ class TestNewEntityModal(unittest.TestCase):
         modal.selected_factory = self.data_sources[0]
         # An empty DataSourceModel with no editable traits
         modal.model = DummyDataSourceModel(self.data_sources[0])
-        self.assertFalse(modal._current_model_editable)
+        self.assertFalse(modal.current_model_editable)
         self.assertIn("No description available", modal.model_description_HTML)
         self.assertIn("No configuration options available",
                       modal._no_config_options_msg)

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -57,10 +57,11 @@ class TestSetupPane(GuiTestAssistant, TestCase):
 
     def test_add_entity_button(self):
         self.assertEqual(0, len(self.workflow_tree.workflow_mv.mco_mv))
-        self.workflow_tree.factory(
+        self.workflow_tree.on_selection(
+            'MCO',
             self.workflow_tree._factory_registry.mco_factories,
             self.workflow_tree.new_mco,
-            'MCO',
+            None,
             self.workflow_tree.workflow_mv
         )
         self.workflow_tree.entity_creator.model = BaseMCOModel(
@@ -71,20 +72,21 @@ class TestSetupPane(GuiTestAssistant, TestCase):
     def test_remove_entity_button(self):
         self.assertEqual(
             0, len(self.workflow_tree.workflow_mv.execution_layers_mv))
-        self.workflow_tree.factory(
+        self.workflow_tree.on_selection(
+            'ExecutionLayer',
             None,
             self.workflow_tree.new_layer,
-            'ExecutionLayer',
+            None,
             self.workflow_tree.workflow_mv
         )
         self.setup_pane.add_new_entity_btn = True
         self.assertEqual(
             1, len(self.workflow_tree.workflow_mv.execution_layers_mv))
 
-        self.workflow_tree.factory_instance(
+        self.workflow_tree.on_selection(
+            'DataSources',
             self.workflow_tree._factory_registry.data_source_factories,
             self.workflow_tree.new_data_source,
-            'DataSources',
             self.workflow_tree.delete_layer,
             self.workflow_tree.workflow_mv.execution_layers_mv[0]
         )

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -13,6 +13,16 @@ from force_wfmanager.tests.probe_classes import (
 from force_wfmanager.ui.setup.workflow_model_view import (
     WorkflowModelView
 )
+from force_bdss.tests.probe_classes.data_source import (
+    ProbeDataSourceFactory
+)
+from force_bdss.tests.probe_classes.probe_extension_plugin import (
+    ProbeExtensionPlugin
+)
+from force_wfmanager.ui.setup.execution_layers.data_source_model_view import \
+    DataSourceModelView
+from force_wfmanager.utils.variable_names_registry import \
+    VariableNamesRegistry
 
 
 class TestSetupPane(GuiTestAssistant, TestCase):
@@ -27,6 +37,24 @@ class TestSetupPane(GuiTestAssistant, TestCase):
         )
         self.workflow_tree.workflow_mv = WorkflowModelView()
         self.workflow_tree._factory_registry = ProbeFactoryRegistry()
+
+    def test_sync_selected_mv(self):
+
+        plugin = ProbeExtensionPlugin()
+        factory = ProbeDataSourceFactory(plugin=plugin)
+        variable_names_registry = VariableNamesRegistry(
+            workflow=self.workflow_tree.workflow_mv.model)
+
+        model = factory.create_model()
+        data_source_mv = DataSourceModelView(
+            model=model,
+            variable_names_registry=variable_names_registry
+        )
+        self.workflow_tree.selected_mv = data_source_mv
+        self.assertEqual(self.setup_pane.selected_model, model)
+        self.assertEqual(self.setup_pane.selected_model,
+                         self.workflow_tree.selected_mv.model)
+
 
     def test_add_entity_button(self):
         self.assertEqual(0, len(self.workflow_tree.workflow_mv.mco_mv))

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -39,7 +39,6 @@ class TestSetupPane(GuiTestAssistant, TestCase):
         self.workflow_tree._factory_registry = ProbeFactoryRegistry()
 
     def test_sync_selected_mv(self):
-
         plugin = ProbeExtensionPlugin()
         factory = ProbeDataSourceFactory(plugin=plugin)
         variable_names_registry = VariableNamesRegistry(
@@ -50,7 +49,12 @@ class TestSetupPane(GuiTestAssistant, TestCase):
             model=model,
             variable_names_registry=variable_names_registry
         )
-        self.workflow_tree.selected_mv = data_source_mv
+
+        try:
+            self.workflow_tree.selected_mv = data_source_mv
+        except AttributeError:
+            self.fail("ProbeDataSourceModel traits_view not found")
+
         self.assertEqual(self.setup_pane.selected_model, model)
         self.assertEqual(self.setup_pane.selected_model,
                          self.workflow_tree.selected_mv.model)

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -40,10 +40,10 @@ class TestSetupPane(GuiTestAssistant, TestCase):
         plugin = ProbeExtensionPlugin()
         factory = ProbeDataSourceFactory(plugin=plugin)
         model = factory.create_model()
-
+        registry = self.workflow_tree.workflow_mv.variable_names_registry
         data_source_mv = DataSourceModelView(
             model=model,
-            variable_names_registry=self.workflow_tree.workflow_mv.variable_names_registry
+            variable_names_registry=registry
         )
 
         try:

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -21,8 +21,6 @@ from force_bdss.tests.probe_classes.probe_extension_plugin import (
 )
 from force_wfmanager.ui.setup.execution_layers.\
     data_source_model_view import DataSourceModelView
-from force_wfmanager.utils.variable_names_registry import \
-    VariableNamesRegistry
 
 
 class TestSetupPane(GuiTestAssistant, TestCase):
@@ -41,13 +39,11 @@ class TestSetupPane(GuiTestAssistant, TestCase):
     def test_sync_selected_mv(self):
         plugin = ProbeExtensionPlugin()
         factory = ProbeDataSourceFactory(plugin=plugin)
-        variable_names_registry = VariableNamesRegistry(
-            workflow=self.workflow_tree.workflow_mv.model)
-
         model = factory.create_model()
+
         data_source_mv = DataSourceModelView(
             model=model,
-            variable_names_registry=variable_names_registry
+            variable_names_registry=self.workflow_tree.workflow_mv.variable_names_registry
         )
 
         try:

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -19,8 +19,8 @@ from force_bdss.tests.probe_classes.data_source import (
 from force_bdss.tests.probe_classes.probe_extension_plugin import (
     ProbeExtensionPlugin
 )
-from force_wfmanager.ui.setup.execution_layers.data_source_model_view import \
-    DataSourceModelView
+from force_wfmanager.ui.setup.execution_layers.\
+    data_source_model_view import DataSourceModelView
 from force_wfmanager.utils.variable_names_registry import \
     VariableNamesRegistry
 
@@ -54,7 +54,6 @@ class TestSetupPane(GuiTestAssistant, TestCase):
         self.assertEqual(self.setup_pane.selected_model, model)
         self.assertEqual(self.setup_pane.selected_model,
                          self.workflow_tree.selected_mv.model)
-
 
     def test_add_entity_button(self):
         self.assertEqual(0, len(self.workflow_tree.workflow_mv.mco_mv))

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -99,10 +99,11 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertIsNone(self.tree.workflow_mv.model.mco)
         self.assertEqual(len(self.tree.workflow_mv.mco_mv), 0)
 
-        self.tree.factory(
+        self.tree.on_selection(
+            'MCO',
             self.factory_registry.mco_factories,
             self.tree.new_mco,
-            'MCO',
+            None,
             self.tree.workflow_mv
         )
         self.tree.entity_creator.model = (
@@ -122,10 +123,11 @@ class TestWorkflowTree(unittest.TestCase):
         parameter_factory = (
             self.factory_registry.mco_factories[0].parameter_factories[0]
         )
-        self.tree.factory(
+        self.tree.on_selection(
+            'Parameter',
             self.factory_registry.mco_factories[0].parameter_factories,
             self.tree.new_parameter,
-            'Parameter',
+            None,
             self.tree.workflow_mv.mco_mv[0]
         )
         self.tree.entity_creator.model = parameter_factory.create_model()
@@ -144,10 +146,10 @@ class TestWorkflowTree(unittest.TestCase):
             2
         )
 
-        self.tree.factory_instance(
+        self.tree.on_selection(
+            'ExecutionLayer',
             self.factory_registry.data_source_factories,
             self.tree.new_data_source,
-            'ExecutionLayer',
             self.tree.delete_layer,
             exec_layer
         )
@@ -167,10 +169,11 @@ class TestWorkflowTree(unittest.TestCase):
             len(self.tree.workflow_mv.notification_listeners_mv), 1)
         self.assertEqual(
             len(self.tree.workflow_mv.model.notification_listeners), 1)
-        self.tree.factory(
+        self.tree.on_selection(
+            'NotificationListener',
             self.factory_registry.notification_listener_factories,
             self.tree.new_notification_listener,
-            'NotificationListener',
+            None,
             self.tree.workflow_mv
         )
 
@@ -187,10 +190,11 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertEqual(len(self.tree.workflow_mv.mco_mv[0].kpis_mv), 1)
         self.assertEqual(len(self.tree.workflow_mv.model.mco.kpis), 1)
 
-        self.tree.factory(
+        self.tree.on_selection(
+            'KPI',
             None,
             self.tree.new_kpi,
-            'KPI',
+            None,
             self.tree.workflow_mv.mco_mv[0]
         )
         self.tree.add_new_entity()
@@ -202,10 +206,11 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertEqual(len(self.tree.workflow_mv.execution_layers_mv), 2)
         self.assertEqual(len(self.tree.workflow_mv.model.execution_layers), 2)
 
-        self.tree.factory(
+        self.tree.on_selection(
+            'ExecutionLayer',
             None,
             self.tree.new_layer,
-            'ExecutionLayer',
+            None,
             self.tree.workflow_mv
         )
         self.tree.add_new_entity()
@@ -219,8 +224,12 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertEqual(
             len(self.tree.workflow_mv.model.notification_listeners), 1)
         notif_instance = self.tree.workflow_mv.notification_listeners_mv[0]
-        self.tree.instance(
-            self.tree.delete_notification_listener, notif_instance
+        self.tree.on_selection(
+            'None',
+            None,
+            None,
+            self.tree.delete_notification_listener,
+            notif_instance
         )
         self.tree.remove_entity()
 
@@ -233,7 +242,12 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertIsNotNone(self.tree.model.mco)
         self.assertEqual(len(self.tree.workflow_mv.mco_mv), 1)
 
-        self.tree.instance(self.tree.delete_mco, self.tree.workflow_mv.mco_mv)
+        self.tree.on_selection(
+            'None',
+            None,
+            None,
+            self.tree.delete_mco,
+            self.tree.workflow_mv.mco_mv)
         self.tree.remove_entity()
 
         self.assertIsNone(self.tree.model.mco)
@@ -242,7 +256,10 @@ class TestWorkflowTree(unittest.TestCase):
     def test_delete_mco_parameter(self):
         self.assertEqual(len(self.tree.model.mco.parameters), 1)
 
-        self.tree.instance(
+        self.tree.on_selection(
+            'None',
+            None,
+            None,
             self.tree.delete_parameter,
             self.tree.workflow_mv.mco_mv[0].mco_parameters_mv[0]
         )
@@ -255,10 +272,10 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertEqual(len(self.tree.workflow_mv.execution_layers_mv), 2)
         self.assertEqual(len(self.tree.workflow_mv.model.execution_layers), 2)
 
-        self.tree.factory_instance(
+        self.tree.on_selection(
+            'ExecutionLayer',
             self.factory_registry.data_source_factories,
             self.tree.new_data_source,
-            'ExecutionLayer',
             self.tree.delete_layer,
             first_execution_layer
         )
@@ -271,7 +288,10 @@ class TestWorkflowTree(unittest.TestCase):
         self.assertEqual(len(self.tree.workflow_mv.mco_mv[0].kpis_mv), 1)
         self.assertEqual(len(self.tree.workflow_mv.model.mco.kpis), 1)
 
-        self.tree.instance(
+        self.tree.on_selection(
+            'None',
+            None,
+            None,
             self.tree.delete_kpi,
             self.tree.workflow_mv.mco_mv[0].kpis_mv[0]
         )
@@ -291,7 +311,11 @@ class TestWorkflowTree(unittest.TestCase):
             len(self.tree.workflow_mv.model.execution_layers[0].data_sources),
             2)
 
-        self.tree.instance(self.tree.delete_data_source, data_source)
+        self.tree.on_selection(
+            'None',
+            None,
+            None,
+            self.tree.delete_data_source, data_source)
         self.tree.remove_entity()
 
         self.assertEqual(

--- a/force_wfmanager/ui/setup/workflow_info.py
+++ b/force_wfmanager/ui/setup/workflow_info.py
@@ -43,7 +43,7 @@ class WorkflowInfo(HasTraits):
     plugins = List(Plugin)
 
     #: The factory currently selected in the SetupPane
-    selected_factory = Unicode()
+    selected_factory_name = Unicode()
 
     #: The top-level workflow modelview
     workflow_mv = Instance(WorkflowModelView)
@@ -96,7 +96,7 @@ class WorkflowInfo(HasTraits):
                           editor=ImageEditor(scale=True,
                                              allow_upscaling=False,
                                              preserve_aspect_ratio=True)),
-                    visible_when="selected_factory == 'Workflow'"
+                    visible_when="selected_factory_name == 'Workflow'"
                 )
             ),
             Group(
@@ -104,13 +104,13 @@ class WorkflowInfo(HasTraits):
                           editor=ListStrEditor(editable=False)),
                 show_border=True,
                 label='Available Plugins',
-                visible_when="selected_factory not in ['KPI']"
+                visible_when="selected_factory_name not in ['KPI']"
             ),
             Group(
                 UReadonly('non_kpi_variables_rep', editor=table_edit),
                 show_border=True,
                 label='Non-KPI Variables',
-                visible_when="selected_factory == 'KPI'"
+                visible_when="selected_factory_name == 'KPI'"
             ),
             Group(
                 UReadonly('workflow_filename_message', editor=TextEditor()),
@@ -121,7 +121,7 @@ class WorkflowInfo(HasTraits):
                 UReadonly('error_message', editor=TextEditor()),
                 show_border=True,
                 label='Workflow Errors',
-                visible_when="selected_factory == 'Workflow'"
+                visible_when="selected_factory_name == 'Workflow'"
             ),
 
         )

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -441,9 +441,17 @@ class WorkflowTree(ModelView):
                      delete_fn, modelview):
 
         self.selected_factory_name = factory_group_name
+        add_new_entity = None
+        entity_creator = None
+        remove_entity = None
 
         if create_fn is not None:
-            self.add_new_entity = partial(create_fn, None, modelview)
+            add_new_entity = partial(create_fn, None, modelview)
+        self.add_new_entity = add_new_entity
+
+        if delete_fn is not None:
+            remove_entity = partial(delete_fn, None, modelview)
+        self.remove_entity = remove_entity
 
         if from_registry is not None:
             try:
@@ -457,12 +465,8 @@ class WorkflowTree(ModelView):
                 factories=visible_factories,
                 dclick_function=self.add_new_entity
             )
-            self.entity_creator = entity_creator
-        else:
-            self.entity_creator = None
 
-        if delete_fn is not None:
-            self.remove_entity = partial(delete_fn, None, modelview)
+        self.entity_creator = entity_creator
 
     def parameter_factories(self):
         """Returns the list of parameter factories for the current MCO."""

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -70,16 +70,6 @@ delete_layer_action = Action(name='Delete', action='delete_layer')
 # DataSource Actions
 delete_data_source_action = Action(name='Delete', action='delete_data_source')
 
-#: Wrapper to perform workflow verification after a method or function call
-def triggers_verify(func):
-    """Decorator for functions which make changes requiring the workflow to
-    be verified"""
-    @wraps(func)
-    def wrap(self, *args, **kwargs):
-        func(self, *args, **kwargs)
-        self.verify_workflow_event = True
-    return wrap
-
 
 def selection(func):
     """ Decorator for functions called on selecting something in the tree
@@ -528,77 +518,77 @@ class WorkflowTree(ModelView):
     # Additional (unused) args are passed when calling dclick_function by
     # double-clicking a specific factory in the NewEntityCreator
 
-    @triggers_verify
     def new_data_source(self, ui_info, object, *args):
         """Adds a new datasource to the workflow."""
         object.add_data_source(self.entity_creator.model)
         self.entity_creator.reset_model()
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def new_kpi(self, ui_info, object):
         """Adds a new KPI to the workflow"""
         object.add_kpi(KPISpecification())
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def new_layer(self, ui_info, object):
         """Adds a new execution layer to the workflow"""
         object.add_execution_layer(ExecutionLayer())
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def new_mco(self, ui_info, object, *args):
         """Adds a new mco to the workflow"""
         object.set_mco(self.entity_creator.model)
         self.entity_creator.reset_model()
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def new_notification_listener(self, ui_info, object, *args):
         """"Adds a new notification listener to the workflow"""
         object.add_notification_listener(self.entity_creator.model)
         self.entity_creator.reset_model()
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def new_parameter(self, ui_info, object, *args):
         """Adds a new mco parameter to the workflow"""
         object.add_parameter(self.entity_creator.model)
         self.entity_creator.reset_model()
+        self.verify_workflow_event = True
 
     # Methods for deleting entities from the workflow - object is the
     # modelview being deleted.
     # E.g. for delete_data_source the object is a DataSourceModelView
 
-    @triggers_verify
     def delete_data_source(self, ui_info, object):
         """Delete a data source from the workflow"""
         self.workflow_mv.remove_data_source(object.model)
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def delete_kpi(self, ui_info, object):
         """Delete a kpi from the workflow"""
         if len(self.workflow_mv.mco_mv) > 0:
             mco_mv = self.workflow_mv.mco_mv[0]
             mco_mv.remove_kpi(object.model)
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def delete_layer(self, ui_info, object):
         """Delete a execution layer from the workflow"""
         self.workflow_mv.remove_execution_layer(object.model)
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def delete_mco(self, ui_info, object):
         """Delete a mco from the workflow"""
         self.workflow_mv.set_mco(None)
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def delete_notification_listener(self, ui_info, object):
         """Delete a notification listener from the workflow"""
         self.workflow_mv.remove_notification_listener(object.model)
+        self.verify_workflow_event = True
 
-    @triggers_verify
     def delete_parameter(self, ui_info, object):
         """Delete a mco parameter from the workflow"""
         if len(self.workflow_mv.mco_mv) > 0:
             mco_mv = self.workflow_mv.mco_mv[0]
             mco_mv.remove_parameter(object.model)
+        self.verify_workflow_event = True
 
     # Workflow Verification
 

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -1,7 +1,8 @@
-from functools import partial, wraps
+from functools import partial
 
 from traits.api import (
-    Callable, Event, Instance, Property, Unicode, on_trait_change
+    Callable, Event, Instance, Property, Unicode, on_trait_change,
+    cached_property
 )
 from traitsui.api import (
     Action, Group, Menu, ModelView, TextEditor,
@@ -183,7 +184,8 @@ class WorkflowTree(ModelView):
 
     #: The error message currently displayed in the UI.
     selected_error = Property(
-        Unicode(), depends_on="selected_mv,selected_mv.error_message,selected_mv.label"
+        Unicode(), depends_on="selected_mv,selected_mv.error_message,"
+                              "selected_mv.label"
     )
 
     def default_traits_view(self):
@@ -672,6 +674,7 @@ class WorkflowTree(ModelView):
         """
         return model_info(modelview.model) != []
 
+    @cached_property
     def _get_selected_error(self):
         """Returns the error messages for the currently selected modelview"""
         if self.selected_mv is None:

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -47,38 +47,16 @@ no_menu = Menu()
 # Actions!
 # -------------------
 
-# A string to be used as the enabled_when argument for the actions.
-# For reference, in the enabled_when expression namespace, handler is
-# the WorkflowTree instance, object is the modelview for the selected node
-call_modelview_editable = 'handler.modelview_editable(object)'
-
 # MCO Actions
-new_mco_action = Action(name='New MCO...', action='new_mco')
 delete_mco_action = Action(name='Delete', action='delete_mco')
-edit_mco_action = Action(name='Edit...', action='edit_mco',
-                         enabled_when=call_modelview_editable)
 
 # Notification Listener Actions
-new_notification_listener_action = Action(
-    name='New Notification Listener...',
-    action='new_notification_listener'
-)
 delete_notification_listener_action = Action(
     name='Delete',
     action='delete_notification_listener'
 )
-edit_notification_listener_action = Action(
-    name='Edit...',
-    action='edit_notification_listener',
-    enabled_when=call_modelview_editable
-)
 
 # Parameter Actions
-new_parameter_action = Action(name='New Parameter...', action='new_parameter')
-edit_parameter_action = Action(
-    name='Edit...', action='edit_parameter',
-    enabled_when=call_modelview_editable
-)
 delete_parameter_action = Action(name='Delete', action='delete_parameter')
 
 # KPI Actions
@@ -90,16 +68,7 @@ new_layer_action = Action(name="New Layer...", action='new_layer')
 delete_layer_action = Action(name='Delete', action='delete_layer')
 
 # DataSource Actions
-new_data_source_action = Action(
-    name='New DataSource...',
-    action='new_data_source'
-)
 delete_data_source_action = Action(name='Delete', action='delete_data_source')
-edit_data_source_action = Action(
-    name='Edit...', action='edit_data_source',
-    enabled_when=call_modelview_editable
-)
-
 
 #: Wrapper to perform workflow verification after a method or function call
 def triggers_verify(func):
@@ -747,7 +716,6 @@ class WorkflowTree(ModelView):
         modelview: ModelView
             A ModelView
         """
-
         return model_info(modelview.model) != []
 
     def _get_selected_error(self):


### PR DESCRIPTION
Addresses issue in #298

This PR removes the `Property` status from several traits that were being updated via `depends_on='object'` and instead uses the `on_trait_change('object')` on their getter method.

Refactoring communication in this way reduces the number of automated calls taking place, which had become large due to multiple intertwined dependencies. Some `Property` traits have become cached instead, though this has been used sparingly as it neglects to address the underlying issue of messy communication.

In doing so, the `selection` and `trigger_verify` decorators being using in `workflow_tree.py` have also been removed in order to make the code style more uniform. 

Also contains updates from #294 and #296 

## Further work:

Tidying up synchronisation of shared trait attributes between panes, trees and model views.