### PR TITLE
Make TestUiUtils.test_class_description pass from subdirectories

### DIFF
--- a/force_wfmanager/ui/tests/test_ui_utils.py
+++ b/force_wfmanager/ui/tests/test_ui_utils.py
@@ -51,6 +51,21 @@ class TestUiUtils(unittest.TestCase):
 
     def test_class_description(self):
 
+        # Workaround needed if the test is not run from the repository root.
+        allclasses = [
+            HasDescriptionNone, HasShortDescription, HasLongDescription,
+            HasLongerDescription, DescriptionIsLabel
+        ]
+        for cl in allclasses:
+            # This is not a test assertion, but a working assumption. It
+            # should never be false.
+            assert cl.__module__.endswith("test_ui_utils"), \
+                "The test has been invoked in such a way that locally " \
+                "defined classes don't appear as belonging to this module!"
+            # Fakes a module structure that starts at root
+            cl.__module__ = "force_wfmanager.ui.tests.test_ui_utils"
+
+        # Actual test.
         self.assertEqual(
             class_description(HasDescriptionNone),
             "force_wfmanager.ui.tests.test_ui_utils.HasDescriptionNone"


### PR DESCRIPTION
Fixes #315 

The test was designed in order to check different breakpoints based on the length of str(class), so it's essential that str(class) returns the full path starting from the repository root.

If the test is run from a subdirectory, I just change `__module__` in place to its full form.