### PR TITLE
Handling of plot updates and resizes

### DIFF
--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -399,6 +399,27 @@ class BasePlot(BaseDataView):
         self._plot.range2d.y_range.low_setting = y_low
         self._plot.range2d.y_range.high_setting = y_high
 
+    def _get_plot_range(self):
+        """ Helper method to get the size of the current _plot
+
+        Returns
+        ----------
+        x_low: Float
+            Minimum value for x range of plot
+        x_high: Float
+            Maximum value for x range of plot
+        y_low: Float
+            Minimum value for y range of plot
+        y_high: Float
+            Maximum value for y range of plot
+        """
+        return (
+            self._plot.range2d.x_range.low_setting,
+            self._plot.range2d.x_range.high_setting,
+            self._plot.range2d.y_range.low_setting,
+            self._plot.range2d.y_range.high_setting
+        )
+
 
 class Plot(BasePlot):
     """Simple 2D scatter plot with optional colormap (see module doc)."""
@@ -453,11 +474,12 @@ class Plot(BasePlot):
 
     @on_trait_change('color_plot')
     def change_plot_style(self):
+        ranges = self._get_plot_range()
         if self.color_plot:
             self._plot = self.plot_cmap_scatter()
         else:
             self._plot = self.plot_scatter()
-        self.recenter_plot()
+        self._set_plot_range(*ranges)
 
     @on_trait_change('colormap')
     def _update_cmap(self):

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -124,6 +124,7 @@ class BasePlot(BaseDataView):
     def __plot_default(self):
         self._plot = self.plot_scatter()
         self.recenter_plot()
+        self.plot_updater.Start()
         return self._plot
 
     def _get_scatter_inspector_overlay(self, scatter_plot):

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -476,11 +476,17 @@ class Plot(BasePlot):
     @on_trait_change('color_plot')
     def change_plot_style(self):
         ranges = self._get_plot_range()
+        x_title = self._plot.x_axis.title
+        y_title = self._plot.y_axis.title
+
         if self.color_plot:
             self._plot = self.plot_cmap_scatter()
         else:
             self._plot = self.plot_scatter()
+
         self._set_plot_range(*ranges)
+        self._plot.x_axis.title = x_title
+        self._plot.y_axis.title = y_title
 
     @on_trait_change('colormap')
     def _update_cmap(self):

--- a/force_wfmanager/ui/review/tests/test_plot.py
+++ b/force_wfmanager/ui/review/tests/test_plot.py
@@ -298,3 +298,5 @@ class TestPlot(TestAnyPlot, unittest.TestCase):
         self.plot.color_plot = True
         self.plot.color_by = 'color'
         self.assertEqual(self.plot._get_plot_range(), (0.5, 2, 100000, 103000))
+        self.assertEqual(self.plot._plot.x_axis.title, "density")
+        self.assertEqual(self.plot._plot.y_axis.title, "pressure")

--- a/force_wfmanager/ui/review/tests/test_plot.py
+++ b/force_wfmanager/ui/review/tests/test_plot.py
@@ -68,6 +68,20 @@ class TestAnyPlot(object):
             time.sleep(1.1)
             mock_update_plot.assert_called()
 
+    def test_check_scheduled_updates(self):
+        with mock.patch(
+                "force_wfmanager.ui.review.plot."
+                + self.plot.__class__.__name__
+                + "._update_plot") as mock_update_plot:
+            self.assertFalse(self.plot.update_required)
+            self.plot._check_scheduled_updates()
+            mock_update_plot.assert_not_called()
+
+            self.plot.update_required = True
+            self.plot._check_scheduled_updates()
+            mock_update_plot.assert_called()
+            self.assertFalse(self.plot.update_required)
+
     def test_push_new_evaluation_steps(self):
         self.analysis_model.value_names = ('density', 'pressure')
         self.analysis_model.add_evaluation_step((1.010, 101325))


### PR DESCRIPTION
This PR
- reworks the listeners' logic in `BasePlot`, to close #318, and to remove the `timer.Stop()` call that wasn't working. Now the changes of axes triggers a recenter; the plot ranges are updated based on the timer but only if there were changes in the `evaluation_steps`
- allows switching from colormapped to non-colormapped and back, without losing the pan & zoom