### PR TITLE
New Design of VariableNamesRegistry to aid Input/Output slot sync

### DIFF
--- a/force_wfmanager/ui/setup/mco/base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/base_mco_options_model_view.py
@@ -1,13 +1,12 @@
 from traits.api import (
-    Bool, Event, Instance, List, Property, Unicode,
-    on_trait_change, Either, Tuple
+    Bool, Event, Instance, List, Unicode, Either, on_trait_change
 )
 from traitsui.api import (
     ModelView
 )
 
 from force_bdss.api import (
-    KPISpecification, BaseMCOParameter, Identifier
+    KPISpecification, BaseMCOParameter
 )
 from force_wfmanager.utils.variable_names_registry import (
     Variable
@@ -60,6 +59,21 @@ class BaseMCOOptionsModelView(ModelView):
     # ------------------
     #     Listeners
     # ------------------
+    @on_trait_change('selected_variable,available_variables')
+    def _check_available_variables(self):
+
+        if self.selected_variable is not None:
+            if self.selected_variable not in self.available_variables:
+                self.selected_variable = None
+
+    @on_trait_change('selected_variable')
+    def _check_selected_model(self):
+
+        if self.selected_variable is None:
+            if self.model is not None:
+                self.model.name = ''
+                if isinstance(self.model, BaseMCOParameter):
+                    self.model.type = ''
 
     # Assign an on_trait_change decorator to specify traits to listen to
     # in child class implementation

--- a/force_wfmanager/ui/setup/mco/kpi_specification_model_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_model_view.py
@@ -2,7 +2,7 @@ from traits.api import (
     Property, Instance, Unicode, on_trait_change
 )
 from traitsui.api import (
-    Item, View, EnumEditor
+    Item, View, InstanceEditor
 )
 
 from force_wfmanager.ui.setup.mco.base_mco_options_model_view import \
@@ -26,8 +26,11 @@ class KPISpecificationModelView(BaseMCOOptionsModelView):
     # model.name listed in kpi_names. However, it is possible
     # to directly change model.name without updating kpi_names
     traits_view = View(
-        Item('name', object='model',
-             editor=EnumEditor(name='object._combobox_values')),
+        Item('selected_variable',
+             editor=InstanceEditor(
+                 name='available_variables',
+                 editable=False)
+                     ),
         Item("objective", object='model'),
         Item('auto_scale', object='model'),
         Item("scale_factor", object='model',
@@ -46,3 +49,8 @@ class KPISpecificationModelView(BaseMCOOptionsModelView):
     @on_trait_change('model.[name,objective]')
     def kpi_model_change(self):
         self.model_change()
+
+    @on_trait_change('selected_variable.name')
+    def selected_variable_change(self):
+        if self.model is not None:
+            self.model.name = self.selected_variable.name

--- a/force_wfmanager/ui/setup/mco/kpi_specification_model_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_model_view.py
@@ -29,8 +29,9 @@ class KPISpecificationModelView(BaseMCOOptionsModelView):
         Item('selected_variable',
              editor=InstanceEditor(
                  name='available_variables',
-                 editable=False)
-                     ),
+                 editable=False
+             )
+             ),
         Item("objective", object='model'),
         Item('auto_scale', object='model'),
         Item("scale_factor", object='model',
@@ -43,14 +44,17 @@ class KPISpecificationModelView(BaseMCOOptionsModelView):
         """Gets the label from the model object"""
         if self.model.name == '':
             return "KPI"
-        return "KPI: {} ({})".format(self.model.name, self.model.objective)
+        return "KPI: {} ({})".format(
+            self.model.name, self.model.objective
+        )
 
     #: Listeners
-    @on_trait_change('model.[name,objective]')
-    def kpi_model_change(self):
-        self.model_change()
-
-    @on_trait_change('selected_variable.name')
+    @on_trait_change('model.name,'
+                     'selected_variable.name')
     def selected_variable_change(self):
+        """Syncs the model name with the selected variable name
+        (prevents direct changes to the KPISpecifications model)"""
         if self.model is not None:
-            self.model.name = self.selected_variable.name
+            if self.selected_variable is not None:
+                self.model.name = self.selected_variable.name
+            self.model_change()

--- a/force_wfmanager/ui/setup/mco/kpi_specification_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_view.py
@@ -29,11 +29,6 @@ class KPISpecificationView(BaseMCOOptionsView):
     #     Properties
     # ------------------
 
-    #: The names of the KPIs in the Workflow.
-    kpi_names = Property(
-        List(Unicode), depends_on='model.kpis.name'
-    )
-
     #: A list names, each representing a variable
     #: that could become a KPI
     kpi_name_options = Property(
@@ -115,15 +110,6 @@ class KPISpecificationView(BaseMCOOptionsView):
     # -------------------
     #     Listeners
     # -------------------
-
-    @cached_property
-    def _get_kpi_names(self):
-        """Listens to model.kpis to extract model names for display"""
-        kpi_names = []
-        for kpi in self.model.kpis:
-            kpi_names.append(kpi.name)
-
-        return kpi_names
 
     @cached_property
     def _get_kpi_name_options(self):

--- a/force_wfmanager/ui/setup/mco/kpi_specification_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_view.py
@@ -34,7 +34,7 @@ class KPISpecificationView(BaseMCOOptionsView):
     #: that could become a KPI
     kpi_name_options = Property(
         List(Variable),
-        depends_on='variable_names_registry.variable_database'
+        depends_on='variable_names_registry.variable_registry'
     )
 
     # ------------------
@@ -121,7 +121,8 @@ class KPISpecificationView(BaseMCOOptionsView):
          possible names for new KPIs"""
         kpi_name_options = []
         if self.variable_names_registry is not None:
-            for key, value in self.variable_names_registry.variable_database.items():
+            registry = self.variable_names_registry.variable_registry
+            for key, value in registry.items():
                 if len(value.inputs) == 0:
                     kpi_name_options.append(value)
 

--- a/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
@@ -2,8 +2,7 @@ from traits.api import (
     cached_property, Property, Instance, Unicode, on_trait_change
 )
 from traitsui.api import (
-    View, Item, InstanceEditor, Readonly,
-    EnumEditor
+    View, Item, InstanceEditor, Readonly
 )
 
 from force_wfmanager.ui.setup.mco.base_mco_options_model_view import \
@@ -28,8 +27,11 @@ class MCOParameterModelView(BaseMCOOptionsModelView):
         """Default view containing both traits from the base class and
         any additional user-defined traits"""
 
-        return View(Item('name', object='model',
-                         editor=EnumEditor(name='object._combobox_values')),
+        return View(Item('selected_variable',
+                         editor=InstanceEditor(
+                             name='available_variables',
+                             editable=False)
+                         ),
                     Readonly('type', object='model'),
                     Item('model',
                          editor=InstanceEditor(),
@@ -58,13 +60,9 @@ class MCOParameterModelView(BaseMCOOptionsModelView):
             type=self.model.type, name=self.model.name
         )
 
-    @on_trait_change('model.[name,type]')
-    def parameter_model_change(self):
+    @on_trait_change('selected_variable.[name,type]')
+    def selected_variable_change(self):
         if self.model is not None:
-            try:
-                index = self._combobox_values.index(self.model.name)
-                self.model.type = self.available_variables[index][1]
-            except ValueError:
-                self.model.type = ''
-
+            self.model.name = self.selected_variable.name
+            self.model.type = self.selected_variable.type
         self.model_change()

--- a/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
@@ -54,15 +54,21 @@ class MCOParameterModelView(BaseMCOOptionsModelView):
     def _get_label(self):
         """Return a label appending both the parameter name and type to the
         default"""
-        if self.model.name == '' and self.model.type == '':
+        if self.model is None:
+            return self._label_default()
+        if self.selected_variable is None:
             return self._label_default()
         return self._label_default()+': {type} {name}'.format(
             type=self.model.type, name=self.model.name
         )
 
-    @on_trait_change('selected_variable.[name,type]')
+    @on_trait_change('model.[name,type],'
+                     'selected_variable.[name,type]')
     def selected_variable_change(self):
+        """Syncs the model name and type with the selected variable name
+        and type (prevents direct changes to the MCOParameter model)"""
         if self.model is not None:
-            self.model.name = self.selected_variable.name
-            self.model.type = self.selected_variable.type
-        self.model_change()
+            if self.selected_variable is not None:
+                self.model.name = self.selected_variable.name
+                self.model.type = self.selected_variable.type
+            self.model_change()

--- a/force_wfmanager/ui/setup/mco/mco_parameter_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_view.py
@@ -155,7 +155,8 @@ class MCOParameterView(BaseMCOOptionsView):
             inputs = self.variable_names_registry.data_source_inputs
             parameter_name_options += (
                 [input_ for input_ in inputs
-                 if input_ not in outputs]
+                 if input_ not in outputs and
+                 input_ not in parameter_name_options]
             )
 
         return parameter_name_options

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
@@ -2,11 +2,10 @@ import unittest
 
 from traits.testing.unittest_tools import UnittestTools
 
-from force_bdss.api import KPISpecification
-
 from force_wfmanager.ui.setup.mco.base_mco_options_model_view import (
     BaseMCOOptionsModelView
 )
+from force_wfmanager.utils.variable_names_registry import Variable
 
 
 class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
@@ -18,28 +17,25 @@ class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
     def test_mco_options_model_view_init(self):
 
         self.assertIsNone(self.mco_options_model_view.model)
+        self.assertIsNone(self.mco_options_model_view.selected_variable)
+        self.assertEqual(
+            0, len(self.mco_options_model_view.available_variables)
+        )
         self.assertTrue(self.mco_options_model_view.valid)
 
-    def test__check_model_name(self):
+    def test__check_selected_model(self):
+        variable1 = Variable(
+            name='T1',
+            type='PRESSURE'
+        )
+        self.mco_options_model_view.selected_variable = variable1
+        self.assertIsNone(self.mco_options_model_view.selected_variable)
 
         self.mco_options_model_view.available_variables = (
-            [('T1', 'PRESSURE'), ('T2', 'PRESSURE')]
+            [variable1]
         )
-        self.assertEqual(['T1', 'T2'],
-                         self.mco_options_model_view._combobox_values)
-        self.mco_options_model_view.model = KPISpecification(name='T1')
+        self.mco_options_model_view.selected_variable = variable1
+        self.assertIsNotNone(self.mco_options_model_view.selected_variable)
 
-        self.mco_options_model_view.available_variables.remove(
-            self.mco_options_model_view.available_variables[-1]
-        )
-        self.assertTrue(self.mco_options_model_view.valid)
-        self.mco_options_model_view.available_variables.remove(
-            self.mco_options_model_view.available_variables[0]
-        )
-
-        self.assertEqual('', self.mco_options_model_view.model.name)
-        error_message = self.mco_options_model_view.model.verify()
-        self.assertIn(
-            'KPI is not named',
-            error_message[0].local_error
-        )
+        self.mco_options_model_view.available_variables = []
+        self.assertIsNone(self.mco_options_model_view.selected_variable)

--- a/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_model_view.py
@@ -1,51 +1,90 @@
 import unittest
+
 from traits.testing.unittest_tools import UnittestTools
 
 from force_bdss.api import KPISpecification
+
 from force_wfmanager.ui.setup.mco.kpi_specification_model_view import \
     KPISpecificationModelView
+from force_wfmanager.ui.ui_utils import model_info
+from force_wfmanager.utils.variable_names_registry import Variable
 
 
 class TestKPISpecificationModelView(unittest.TestCase, UnittestTools):
 
     def setUp(self):
-
+        self.variable = Variable(
+            type='PRESSURE',
+            layer=0,
+            name='T1'
+        )
         self.kpi_model_view = KPISpecificationModelView(
-            model=KPISpecification(name='T1'),
-            available_variables=[('T1', 'PRESSURE'),
-                                 ('T2', 'PRESSURE')]
+            model=KPISpecification(),
+            available_variables=[self.variable],
+            selected_variable=self.variable
         )
 
     def test_kpi_model_view_init(self):
+        self.assertIsNotNone(self.kpi_model_view.model)
+        self.assertIsNotNone(self.kpi_model_view.selected_variable)
+
+        self.assertEqual('T1', self.kpi_model_view.model.name)
         self.assertEqual(
             "KPI: T1 (MINIMISE)",
             self.kpi_model_view.label
         )
         self.assertTrue(self.kpi_model_view.valid)
 
-    def test_kpi_label(self):
-        self.kpi_model_view.model.name = 'T2'
+    def test_kpi_model_update(self):
+        # Should prevent direct changes to the model name
+        self.kpi_model_view.model.name = 'V1'
+        self.assertEqual('T1', self.kpi_model_view.model.name)
         self.assertEqual(
-            "KPI: T2 (MINIMISE)",
+            "KPI: T1 (MINIMISE)",
             self.kpi_model_view.label
         )
 
+        # UI can alter other attributes, however
+        self.kpi_model_view.model.objective = 'MAXIMISE'
+        self.assertEqual(
+            "KPI: T1 (MAXIMISE)",
+            self.kpi_model_view.label
+        )
+
+    def test_kpi_label(self):
+        self.kpi_model_view.selected_variable.name = 'V1'
+        self.kpi_model_view.selected_variable.type = 'VOLUME'
+
+        self.assertEqual('V1', self.kpi_model_view.model.name)
+        self.assertEqual(
+            "KPI: V1 (MINIMISE)",
+            self.kpi_model_view.label,
+        )
+
     def test_verify_workflow_event(self):
-        with self.assertTraitChanges(
-                self.kpi_model_view, 'verify_workflow_event', count=1):
-            self.kpi_model_view.model.name = 'T2'
+        new_variable = Variable(
+            type='PRESSURE',
+            layer=0,
+            name='T2'
+        )
+        self.kpi_model_view.available_variables.append(
+            new_variable
+        )
         with self.assertTraitChanges(
                 self.kpi_model_view, 'verify_workflow_event', count=2):
-            self.kpi_model_view.model.name = 'not_in__combobox'
+            self.kpi_model_view.selected_variable = new_variable
+            self.assertEqual('T2', self.kpi_model_view.model.name)
+        with self.assertTraitChanges(
+                self.kpi_model_view, 'verify_workflow_event', count=2):
+            self.kpi_model_view.model.name = 'T1'
+            self.assertEqual('T2', self.kpi_model_view.model.name)
 
     def test__check_kpi_name(self):
-        self.kpi_model_view.available_variables.remove(
-            self.kpi_model_view.available_variables[-1]
-        )
         self.assertTrue(self.kpi_model_view.valid)
         self.kpi_model_view.available_variables.remove(
-            self.kpi_model_view.available_variables[-1]
+            self.kpi_model_view.selected_variable
         )
+        self.assertIsNone(self.kpi_model_view.selected_variable)
         self.assertEqual(
             "KPI",
             self.kpi_model_view.label
@@ -56,3 +95,7 @@ class TestKPISpecificationModelView(unittest.TestCase, UnittestTools):
             'KPI is not named',
             error_message[0].local_error
         )
+
+    def test_traits_view(self):
+        info = model_info(self.kpi_model_view)
+        self.assertIn('selected_variable', info)

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_model_view.py
@@ -7,6 +7,8 @@ from force_bdss.tests.probe_classes.mco import ProbeParameterFactory
 
 from force_wfmanager.ui.setup.mco.mco_parameter_model_view import \
     MCOParameterModelView
+from force_wfmanager.ui.ui_utils import model_info
+from force_wfmanager.utils.variable_names_registry import Variable
 
 
 class TestMCOParameterModelView(unittest.TestCase, UnittestTools):
@@ -15,51 +17,70 @@ class TestMCOParameterModelView(unittest.TestCase, UnittestTools):
         self.plugin = ProbeExtensionPlugin()
         self.mco_factory = self.plugin.mco_factories[0]
         self.parameter_factory = ProbeParameterFactory(self.mco_factory)
+        self.variable = Variable(
+            type='PRESSURE',
+            layer=0,
+            name='P1'
+        )
         self.parameter_model_view = MCOParameterModelView(
             model=self.parameter_factory.create_model(),
-            available_variables=[('P1', 'PRESSURE')]
+            available_variables=[self.variable],
+            selected_variable=self.variable
         )
 
     def test_mco_parameter_view_init(self):
+        self.assertIsNotNone(self.parameter_model_view.model)
+        self.assertIsNotNone(self.parameter_model_view.selected_variable)
+
+        self.assertEqual('P1', self.parameter_model_view.model.name)
+        self.assertEqual('PRESSURE', self.parameter_model_view.model.type)
         self.assertEqual(
-            "Probe parameter", self.parameter_model_view.label,
+            "Probe parameter: PRESSURE P1",
+            self.parameter_model_view.label,
         )
-        self.assertEqual(self.parameter_model_view.label,
-                         "Probe parameter")
 
     def test_parameter_model_update(self):
-        self.parameter_model_view.model.name = 'P1'
+        # Should prevent direct changes to the model name and type
+        self.parameter_model_view.model.name = 'V1'
+        self.parameter_model_view.model.type = 'VOLUME'
+
+        self.assertEqual('P1', self.parameter_model_view.model.name)
         self.assertEqual('PRESSURE', self.parameter_model_view.model.type)
+        self.assertEqual(
+            "Probe parameter: PRESSURE P1",
+            self.parameter_model_view.label,
+        )
 
     def test_mco_parameter_label(self):
-        self.parameter_model_view.model.name = 'P1'
-        self.assertEqual(self.parameter_model_view.label,
-                         "Probe parameter: PRESSURE P1")
+        self.parameter_model_view.selected_variable.name = 'V1'
+        self.parameter_model_view.selected_variable.type = 'VOLUME'
+
+        self.assertEqual('V1', self.parameter_model_view.model.name)
+        self.assertEqual('VOLUME', self.parameter_model_view.model.type)
+        self.assertEqual(
+            "Probe parameter: VOLUME V1",
+            self.parameter_model_view.label,
+        )
 
     def test_verify_workflow_event(self):
+        new_variable = Variable(
+            type='PRESSURE',
+            layer=0,
+            name='T2'
+        )
         self.parameter_model_view.available_variables.append(
-            ('T2', 'PRESSURE')
+            new_variable
         )
         with self.assertTraitChanges(
                 self.parameter_model_view, 'verify_workflow_event', count=2):
-            self.parameter_model_view.model.name = 'T2'
+            self.parameter_model_view.selected_variable = new_variable
+            self.assertEqual('T2', self.parameter_model_view.model.name)
         with self.assertTraitChanges(
-                self.parameter_model_view, 'verify_workflow_event', count=3):
-            self.parameter_model_view.model.name = 'another'
+                self.parameter_model_view, 'verify_workflow_event', count=2):
+            self.parameter_model_view.model.name = 'T1'
+            self.assertEqual('T2', self.parameter_model_view.model.name)
 
     def test_traits_view(self):
-        trait_view = self.parameter_model_view.trait_view()
-        trait_view_repr = trait_view.content.__repr__()
-
-        self.assertIn(
-            'name',
-            trait_view_repr,
-        )
-        self.assertIn(
-            'type',
-            trait_view_repr,
-        )
-        self.assertIn(
-            'model',
-            trait_view_repr,
-        )
+        info = model_info(self.parameter_model_view)
+        self.assertIn('selected_variable', info)
+        self.assertIn('model', info)

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_view.py
@@ -114,8 +114,8 @@ class TestMCOParameterView(unittest.TestCase, UnittestTools):
         self.data_source1.input_slot_info = [InputSlotInfo(name='T1')]
         parameter_model_view = self.parameter_view.model_views[0]
         with self.assertTraitChanges(
-                self.parameter_view, 'verify_workflow_event', count=2):
+                self.parameter_view, 'verify_workflow_event', count=1):
             parameter_model_view.model.name = 'T1'
         with self.assertTraitChanges(
-                self.parameter_view, 'verify_workflow_event', count=3):
+                self.parameter_view, 'verify_workflow_event', count=1):
             parameter_model_view.model.name = 'another'

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_view.py
@@ -57,9 +57,6 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
         self.assertEqual(
             'outputA',
             self.kpi_view.model_views[0].model.name)
-        self.assertEqual(
-            'outputA',
-            self.kpi_view.kpi_names[0])
 
         self.assertEqual(2, len(self.parameter_view.model_views))
         self.assertEqual(
@@ -78,7 +75,6 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
         self.kpi_view.add_kpi(kpi_spec)
         self.assertEqual(2, len(self.kpi_view.model_views))
         self.assertEqual(3, len(self.kpi_view.kpi_name_options))
-        self.assertEqual(2, len(self.kpi_view.kpi_names))
         self.assertEqual(self.kpi_view.model_views[1].model, kpi_spec)
         self.assertEqual(
             'outputB',
@@ -86,14 +82,12 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
         self.assertEqual(
             'KPI: outputB (MINIMISE)',
             self.kpi_view.model_views[1].label)
-        self.assertEqual('outputB', self.kpi_view.kpi_names[1])
 
     def test_remove_kpi(self):
         kpi_spec = self.kpi_view.model_views[0].model
         self.kpi_view.remove_kpi(kpi_spec)
         self.assertEqual(0, len(self.kpi_view.model_views))
         self.assertEqual(3, len(self.kpi_view.kpi_name_options))
-        self.assertEqual(0, len(self.kpi_view.kpi_names))
 
     def test_add_parameter(self):
         parameter = BaseMCOParameter(None, name='P3', type='PRESSURE')
@@ -101,7 +95,6 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
         self.parameter_view.add_parameter(parameter)
         self.assertEqual(3, len(self.parameter_view.model_views))
         self.assertEqual(3, len(self.kpi_view.kpi_name_options))
-        self.assertEqual(1, len(self.kpi_view.kpi_names))
         self.assertEqual(
             parameter, self.parameter_view.model_views[2].model)
 
@@ -110,14 +103,15 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
         self.parameter_view.remove_parameter(parameter)
         self.assertEqual(1, len(self.parameter_view.model_views))
         self.assertEqual(3, len(self.kpi_view.kpi_name_options))
-        self.assertEqual(1, len(self.kpi_view.kpi_names))
 
     def test_verify_workflow_event(self):
         parameter_model_view = self.parameter_view.model_views[0]
 
         with self.assertTraitChanges(
-                self.mco_view, 'verify_workflow_event', count=1):
-            parameter_model_view.model.name = 'P2'
+                self.mco_view, 'verify_workflow_event', count=2):
+            variable = parameter_model_view.available_variables[1]
+            parameter_model_view.selected_variable = variable
+            self.assertEqual('P2', parameter_model_view.model.name)
 
         kpi_model_view = self.kpi_view.model_views[0]
         with self.assertTraitChanges(

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -4,12 +4,13 @@ from traits.api import (
     cached_property
 )
 from traitsui.api import (
-    View, Item, TableEditor, VGroup, TextEditor, UReadonly
+    View, Item, TableEditor, VGroup, TextEditor, UReadonly,
+    EnumEditor
 )
 from traitsui.table_column import ObjectColumn
 
 from force_bdss.api import (BaseDataSourceModel, BaseDataSource,
-                            InputSlotInfo, OutputSlotInfo)
+                            InputSlotInfo, OutputSlotInfo, Identifier)
 
 from force_wfmanager.ui.ui_utils import (
     get_factory_name, get_default_background_color)
@@ -47,6 +48,9 @@ class InputSlotRow(TableRow):
 
     #: Model of the evaluator
     model = Instance(InputSlotInfo)
+
+    # Available names for input variables
+    available_names = List(Identifier)
 
 
 class OutputSlotRow(TableRow):
@@ -308,7 +312,6 @@ class DataSourceView(HasTraits):
         needed by the evaluator and the model slot values """
 
         input_representations = []
-
         for index, input_slot in enumerate(input_slots):
             slot_representation = InputSlotRow(
                 model=self.model.input_slot_info[index],
@@ -336,7 +339,12 @@ class DataSourceView(HasTraits):
         registry = self.variable_names_registry
         idx = self.layer_index
 
-        return registry.available_variables[idx]
+        available_names = []
+
+        for layer in registry.available_variables[:idx]:
+            available_names += layer
+
+        return available_names
 
     def _available_variables_by_type(self, variable_type):
         """Returns the available variables of variable_type for the

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -332,36 +332,6 @@ class DataSourceView(HasTraits):
 
         self.output_slots_representation[:] = output_representation
 
-    def _available_variables(self):
-        """Returns the available variables for the containing execution layer
-        of this data source
-        """
-        registry = self.variable_names_registry
-        idx = self.layer_index
-
-        available_names = []
-
-        for layer in registry.available_variables[:idx]:
-            available_names += layer
-
-        return available_names
-
-    def _available_variables_by_type(self, variable_type):
-        """Returns the available variables of variable_type for the
-        containing execution layer of this data source
-
-        Parameters
-        ----------
-        variable_type: CUBAType
-            Searches for available variables of this type
-        """
-        registry = self.variable_names_registry
-        idx = self.layer_index
-
-        if variable_type in registry.available_variables_by_type[idx]:
-            return registry.available_variables_by_type[idx][variable_type]
-        return []
-
 
 BACKGROUND_COLOR = get_default_background_color()
 

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -4,8 +4,7 @@ from traits.api import (
     cached_property
 )
 from traitsui.api import (
-    View, Item, TableEditor, VGroup, TextEditor, UReadonly,
-    EnumEditor
+    View, Item, TableEditor, VGroup, TextEditor, UReadonly
 )
 from traitsui.table_column import ObjectColumn
 

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -40,11 +40,11 @@ class TestDataSourceView(WfManagerBaseTestCase):
         self.workflow.mco.parameters[0].name = 'P2'
         self.assertEqual('P1', self.model_1.input_slot_info[0].name)
 
-        self.data_source_view.input_slots_representation[0].name = 'P2'
+        self.data_source_view.input_slots_representation[0].model.name = 'P2'
         self.assertEqual('P2', self.model_1.input_slot_info[0].name)
 
     def test_output_slot_update(self):
-        self.data_source_view.output_slots_representation[0].name = 'output'
+        self.data_source_view.output_slots_representation[0].model.name = 'output'
         self.assertEqual('output', self.model_1.output_slot_info[0].name)
 
     def test_bad_input_slots(self):
@@ -77,17 +77,17 @@ class TestDataSourceView(WfManagerBaseTestCase):
 
         self.assertEqual(
             'p1',
-            self.data_source_view.output_slots_representation[0].name
+            self.data_source_view.output_slots_representation[0].model.name
         )
         self.assertEqual(
             't1',
-            self.data_source_view.output_slots_representation[1].name
+            self.data_source_view.output_slots_representation[1].model.name
         )
 
         self.model_1.input_slot_info[0].name = 'P2'
         self.assertEqual(
             'P2',
-            self.data_source_view.input_slots_representation[0].name
+            self.data_source_view.input_slots_representation[0].model.name
         )
 
     def test_HTML_description(self):

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -105,3 +105,6 @@ class TestDataSourceView(WfManagerBaseTestCase):
                       self.data_source_view.selected_slot_description)
         self.assertIn("PRESSURE",
                       self.data_source_view.selected_slot_description)
+
+    def test__available_variables(self):
+        self.data_source_view._available_variables()

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -44,7 +44,8 @@ class TestDataSourceView(WfManagerBaseTestCase):
         self.assertEqual('P2', self.model_1.input_slot_info[0].name)
 
     def test_output_slot_update(self):
-        self.data_source_view.output_slots_representation[0].model.name = 'output'
+        model = self.data_source_view.output_slots_representation[0].model
+        model.name = 'output'
         self.assertEqual('output', self.model_1.output_slot_info[0].name)
 
     def test_bad_input_slots(self):
@@ -105,6 +106,3 @@ class TestDataSourceView(WfManagerBaseTestCase):
                       self.data_source_view.selected_slot_description)
         self.assertIn("PRESSURE",
                       self.data_source_view.selected_slot_description)
-
-    def test__available_variables(self):
-        self.data_source_view._available_variables()

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -377,7 +377,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.system_state.selected_view = mco_view.parameter_view
         self.assertIn("No errors", self.workflow_tree.selected_error)
 
-        mco_view.parameter_view.model_views[0].model.name = ''
+        mco_view.parameter_view.model_views[0].selected_variable = None
         self.assertIn("An MCO parameter is not named",
                       self.workflow_tree.selected_error)
         self.assertIn("An MCO parameter has no type set",

--- a/force_wfmanager/ui/setup/tests/test_workflow_view.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_view.py
@@ -38,8 +38,6 @@ class TestWorkflowView(WfManagerBaseTestCase, UnittestTools):
         self.assertEqual(
             2, len(parameter_view.model_views))
         self.assertEqual(
-            1, len(kpi_view.kpi_names))
-        self.assertEqual(
             1, len(kpi_view.model_views))
         self.assertEqual(
             3, len(kpi_view.kpi_name_options))
@@ -86,8 +84,6 @@ class TestWorkflowView(WfManagerBaseTestCase, UnittestTools):
         self.assertEqual(
             0, len(kpi_view.model_views))
         self.assertEqual(
-            0, len(kpi_view.kpi_names))
-        self.assertEqual(
             3, len(kpi_view.kpi_name_options))
 
     def test_reset_process(self):
@@ -119,7 +115,6 @@ class TestWorkflowView(WfManagerBaseTestCase, UnittestTools):
             1, len(process_view.execution_layer_views[1]
                    .data_source_views))
         self.assertEqual(0, len(kpi_view.kpi_name_options))
-        self.assertEqual(1, len(kpi_view.kpi_names))
 
     def test_add_output_variable(self):
 
@@ -144,12 +139,13 @@ class TestWorkflowView(WfManagerBaseTestCase, UnittestTools):
         data_source.output_slot_info = [OutputSlotInfo(name='outputD')]
 
         with self.assertTraitChanges(
-                kpi_view, 'kpi_name_options', count=1):
+                kpi_view, 'kpi_name_options', count=2):
             execution_layer_view.add_data_source(data_source)
 
         self.assertEqual(
             3, len(execution_layer_view.data_source_views)
         )
+
         self.assertEqual(
-            4, len(kpi_view.kpi_name_options)
+            5, len(kpi_view.kpi_name_options)
         )

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -84,17 +84,19 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.data_source1.input_slot_info = [InputSlotInfo(name='V1')]
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
 
-        self.assertEqual([[('V1', 'PRESSURE')], []],
+        self.assertEqual([[('V1', 'PRESSURE', self.data_source1)], []],
                          self.registry.available_input_variables_stack[0])
-        self.assertEqual([[('T1', 'PRESSURE')], []],
+        self.assertEqual([[('T1', 'PRESSURE', self.data_source1)], []],
                          self.registry.available_output_variables_stack[0])
 
         self.data_source2.input_slot_info = [InputSlotInfo(name='V2')]
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
 
-        self.assertEqual([[('V1', 'PRESSURE')], [('V2', 'PRESSURE')]],
+        self.assertEqual([[('V1', 'PRESSURE', self.data_source1)],
+                          [('V2', 'PRESSURE', self.data_source2)]],
                          self.registry.available_input_variables_stack[0])
-        self.assertEqual([[('T1', 'PRESSURE')], [('T2', 'PRESSURE')]],
+        self.assertEqual([[('T1', 'PRESSURE', self.data_source1)],
+                          [('T2', 'PRESSURE', self.data_source2)]],
                          self.registry.available_output_variables_stack[0])
 
         self.data_source3.input_slot_info = [InputSlotInfo(name='T1')]

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -160,8 +160,8 @@ class VariableNamesRegistryTest(unittest.TestCase):
                           ("T1", 'PRESSURE')],
                          self.registry.data_source_inputs)
 
-    def test_update_variable_database(self):
-        database = self.registry.variable_database
+    def test_update_variable_registry(self):
+        database = self.registry.variable_registry
 
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
         self.data_source3.input_slot_info = [InputSlotInfo(name='T1')]
@@ -194,7 +194,6 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.assertIsNone(variable_list[3].origin)
 
         self.data_source2.input_slot_info = [InputSlotInfo(name='P1')]
-        variable_list = list(database.values())
 
 
 class VariableTest(unittest.TestCase):

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -84,26 +84,26 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.data_source1.input_slot_info = [InputSlotInfo(name='V1')]
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
 
-        self.assertEqual([('V1', 'PRESSURE', self.data_source1)],
+        self.assertEqual([('V1', 'PRESSURE')],
                          self.registry.available_input_variables_stack[0])
-        self.assertEqual([('T1', 'PRESSURE', self.data_source1)],
+        self.assertEqual([('T1', 'PRESSURE')],
                          self.registry.available_output_variables_stack[0])
 
         self.data_source2.input_slot_info = [InputSlotInfo(name='V2')]
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
 
-        self.assertEqual([('V1', 'PRESSURE', self.data_source1),
-                          ('V2', 'PRESSURE', self.data_source2)],
+        self.assertEqual([('V1', 'PRESSURE'),
+                          ('V2', 'PRESSURE')],
                          self.registry.available_input_variables_stack[0])
-        self.assertEqual([('T1', 'PRESSURE', self.data_source1),
-                          ('T2', 'PRESSURE', self.data_source2)],
+        self.assertEqual([('T1', 'PRESSURE'),
+                          ('T2', 'PRESSURE')],
                          self.registry.available_output_variables_stack[0])
 
         self.data_source3.input_slot_info = [InputSlotInfo(name='T1')]
         self.data_source3.output_slot_info = [OutputSlotInfo(name='T3')]
-        self.assertEqual([('T1', 'PRESSURE', self.data_source3)],
+        self.assertEqual([('T1', 'PRESSURE')],
                          self.registry.available_input_variables_stack[1])
-        self.assertEqual([('T3', 'PRESSURE', self.data_source3)],
+        self.assertEqual([('T3', 'PRESSURE')],
                          self.registry.available_output_variables_stack[1])
 
         self.data_source3.input_slot_info = [InputSlotInfo(name='')]
@@ -123,11 +123,11 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.data_source3.output_slot_info = [OutputSlotInfo(name='P1')]
 
         self.assertEqual(
-            3,
+            4,
             len(self.registry.available_variables)
         )
         self.assertEqual(
-            [['V1', 'V2', 'T1', 'T2'], ['T1', 'P1'], []],
+            [[''], ['V1', 'V2', 'T1', 'T2'], ['T1', 'P1'], []],
             self.registry.available_variables
         )
         self.assertEqual(
@@ -138,7 +138,7 @@ class VariableNamesRegistryTest(unittest.TestCase):
 
         self.data_source1.input_slot_info[0].name = 'V2'
         self.assertEqual(
-            [['V2', 'V2', 'T1', 'T2'], ['T1', 'P1'], []],
+            [[''], ['V2', 'V2', 'T1', 'T2'], ['T1', 'P1'], []],
             self.registry.available_variables
         )
         self.assertEqual(
@@ -152,12 +152,12 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.assertEqual(self.registry.data_source_outputs, [])
 
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
-        self.assertEqual([("T1", 'PRESSURE', self.data_source1)],
+        self.assertEqual([("T1", 'PRESSURE')],
                          self.registry.data_source_outputs)
 
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
-        self.assertEqual([("T1", 'PRESSURE', self.data_source1),
-                          ("T2", 'PRESSURE', self.data_source2)],
+        self.assertEqual([("T1", 'PRESSURE'),
+                          ("T2", 'PRESSURE')],
                          self.registry.data_source_outputs, )
 
     def test_data_source_inputs(self):
@@ -166,11 +166,11 @@ class VariableNamesRegistryTest(unittest.TestCase):
 
         self.data_source1.input_slot_info = [InputSlotInfo(name='V1')]
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
-        self.assertEqual([("V1", 'PRESSURE', self.data_source1)],
+        self.assertEqual([("V1", 'PRESSURE')],
                          self.registry.data_source_inputs)
 
         self.data_source2.input_slot_info = [InputSlotInfo(name='T1')]
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
-        self.assertEqual([("V1", 'PRESSURE', self.data_source1),
-                          ("T1", 'PRESSURE', self.data_source2)],
+        self.assertEqual([("V1", 'PRESSURE'),
+                          ("T1", 'PRESSURE')],
                          self.registry.data_source_inputs)

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -174,3 +174,54 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.assertEqual([("V1", 'PRESSURE'),
                           ("T1", 'PRESSURE')],
                          self.registry.data_source_inputs)
+
+    def test_update_variable_database(self):
+        self.data_source1.input_slot_info = [InputSlotInfo(name='V1')]
+        self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
+        self.data_source3.input_slot_info = [InputSlotInfo(name='T1')]
+        self.data_source3.output_slot_info = [OutputSlotInfo(name='P1')]
+
+        database = self.registry.variable_database
+        variable_list = list(database.values())
+
+        self.assertEqual(3, len(variable_list))
+        self.assertIn('V1:PRESSURE', database.keys())
+
+        self.assertEqual('PRESSURE V1', variable_list[0].label)
+        self.assertEqual('PRESSURE T1', variable_list[1].label)
+        self.assertEqual('PRESSURE P1', variable_list[2].label)
+
+        self.assertIsNone(variable_list[0].origin)
+        self.assertIsNotNone(variable_list[1].origin)
+        self.assertIsNotNone(variable_list[2].origin)
+
+        self.data_source1.output_slot_info = [OutputSlotInfo(name='B1')]
+
+        variable_list = list(database.values())
+
+        self.assertEqual(4, len(variable_list))
+
+        self.assertEqual('PRESSURE V1', variable_list[0].label)
+        self.assertEqual('PRESSURE P1', variable_list[1].label)
+        self.assertEqual('PRESSURE B1', variable_list[2].label)
+        self.assertEqual('PRESSURE T1', variable_list[3].label)
+
+        self.assertIsNone(variable_list[0].origin)
+        self.assertIsNotNone(variable_list[1].origin)
+        self.assertIsNotNone(variable_list[2].origin)
+        self.assertIsNone(variable_list[3].origin)
+
+        self.data_source1.output_slot_info[0].name = 'T1'
+
+        variable_list = list(database.values())
+
+        self.assertEqual(3, len(variable_list))
+        self.assertIn('V1:PRESSURE', database.keys())
+
+        self.assertEqual('PRESSURE V1', variable_list[0].label)
+        self.assertEqual('PRESSURE P1', variable_list[1].label)
+        self.assertEqual('PRESSURE T1', variable_list[2].label)
+
+        self.assertIsNone(variable_list[0].origin)
+        self.assertIsNotNone(variable_list[1].origin)
+        self.assertIsNotNone(variable_list[2].origin)

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -84,32 +84,32 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.data_source1.input_slot_info = [InputSlotInfo(name='V1')]
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
 
-        self.assertEqual([[('V1', 'PRESSURE', self.data_source1)], []],
+        self.assertEqual([('V1', 'PRESSURE', self.data_source1)],
                          self.registry.available_input_variables_stack[0])
-        self.assertEqual([[('T1', 'PRESSURE', self.data_source1)], []],
+        self.assertEqual([('T1', 'PRESSURE', self.data_source1)],
                          self.registry.available_output_variables_stack[0])
 
         self.data_source2.input_slot_info = [InputSlotInfo(name='V2')]
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
 
-        self.assertEqual([[('V1', 'PRESSURE', self.data_source1)],
-                          [('V2', 'PRESSURE', self.data_source2)]],
+        self.assertEqual([('V1', 'PRESSURE', self.data_source1),
+                          ('V2', 'PRESSURE', self.data_source2)],
                          self.registry.available_input_variables_stack[0])
-        self.assertEqual([[('T1', 'PRESSURE', self.data_source1)],
-                          [('T2', 'PRESSURE', self.data_source2)]],
+        self.assertEqual([('T1', 'PRESSURE', self.data_source1),
+                          ('T2', 'PRESSURE', self.data_source2)],
                          self.registry.available_output_variables_stack[0])
 
         self.data_source3.input_slot_info = [InputSlotInfo(name='T1')]
         self.data_source3.output_slot_info = [OutputSlotInfo(name='T3')]
-        self.assertEqual([[('T1', 'PRESSURE')]],
+        self.assertEqual([('T1', 'PRESSURE', self.data_source3)],
                          self.registry.available_input_variables_stack[1])
-        self.assertEqual([[('T3', 'PRESSURE')]],
+        self.assertEqual([('T3', 'PRESSURE', self.data_source3)],
                          self.registry.available_output_variables_stack[1])
 
         self.data_source3.input_slot_info = [InputSlotInfo(name='')]
         self.data_source3.changes_slots = True
         self.data_source3.output_slot_info = [OutputSlotInfo(name='T3')]
-        self.assertEqual([[]],
+        self.assertEqual([],
                          self.registry.available_input_variables_stack[1])
 
     def test_available_variables(self):
@@ -127,22 +127,22 @@ class VariableNamesRegistryTest(unittest.TestCase):
             len(self.registry.available_variables)
         )
         self.assertEqual(
-            [['V1', 'T1', 'V2', 'T2'], ['T1', 'P1'], []],
+            [['V1', 'V2', 'T1', 'T2'], ['T1', 'P1'], []],
             self.registry.available_variables
         )
         self.assertEqual(
-            [{'PRESSURE': ['V1', 'T1', 'V2', 'T2']},
+            [{'PRESSURE': ['V1', 'V2', 'T1', 'T2']},
              {'PRESSURE': ['T1', 'P1']}, {}],
             self.registry.available_variables_by_type
         )
 
         self.data_source1.input_slot_info[0].name = 'V2'
         self.assertEqual(
-            [['V2', 'T1', 'V2', 'T2'], ['T1', 'P1'], []],
+            [['V2', 'V2', 'T1', 'T2'], ['T1', 'P1'], []],
             self.registry.available_variables
         )
         self.assertEqual(
-            [{'PRESSURE': ['V2', 'T1', 'V2', 'T2']},
+            [{'PRESSURE': ['V2', 'V2', 'T1', 'T2']},
              {'PRESSURE': ['T1', 'P1']}, {}],
             self.registry.available_variables_by_type
         )
@@ -152,11 +152,12 @@ class VariableNamesRegistryTest(unittest.TestCase):
         self.assertEqual(self.registry.data_source_outputs, [])
 
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
-        self.assertEqual([("T1", 'PRESSURE')],
+        self.assertEqual([("T1", 'PRESSURE', self.data_source1)],
                          self.registry.data_source_outputs)
 
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
-        self.assertEqual([("T1", 'PRESSURE'), ("T2", 'PRESSURE')],
+        self.assertEqual([("T1", 'PRESSURE', self.data_source1),
+                          ("T2", 'PRESSURE', self.data_source2)],
                          self.registry.data_source_outputs, )
 
     def test_data_source_inputs(self):
@@ -165,10 +166,11 @@ class VariableNamesRegistryTest(unittest.TestCase):
 
         self.data_source1.input_slot_info = [InputSlotInfo(name='V1')]
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
-        self.assertEqual([("V1", 'PRESSURE')],
+        self.assertEqual([("V1", 'PRESSURE', self.data_source1)],
                          self.registry.data_source_inputs)
 
         self.data_source2.input_slot_info = [InputSlotInfo(name='T1')]
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
-        self.assertEqual([("V1", 'PRESSURE'), ("T1", 'PRESSURE')],
+        self.assertEqual([("V1", 'PRESSURE', self.data_source1),
+                          ("T1", 'PRESSURE', self.data_source2)],
                          self.registry.data_source_inputs)

--- a/force_wfmanager/utils/variable_names_registry.py
+++ b/force_wfmanager/utils/variable_names_registry.py
@@ -28,11 +28,11 @@ class VariableNamesRegistry(HasStrictTraits):
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the input variables produced by that execution layer
-    data_source_input = List(Tuple(Identifier, CUBAType, BaseDataSourceModel))
+    data_source_input = Tuple(Identifier, CUBAType, BaseDataSourceModel)
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the output variables produced by that execution layer
-    data_source_output = List(Tuple(Identifier, CUBAType, BaseDataSourceModel))
+    data_source_output = Tuple(Identifier, CUBAType, BaseDataSourceModel)
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the input variables produced by that execution layer
@@ -126,14 +126,12 @@ class VariableNamesRegistry(HasStrictTraits):
 
         for input_layer, output_layer in zip(input_stack, output_stack):
             layer_variables = []
-            generator = zip(input_layer, output_layer)
-            for input_data_source, output_data_source in generator:
-                layer_variables += [
-                    variable[0] for variable in input_data_source
-                ]
-                layer_variables += [
-                    variable[0] for variable in output_data_source
-                ]
+            layer_variables += [
+                variable[0] for variable in input_layer
+            ]
+            layer_variables += [
+                variable[0] for variable in output_layer
+            ]
             variables.append(layer_variables)
 
         return variables
@@ -156,25 +154,23 @@ class VariableNamesRegistry(HasStrictTraits):
 
         for input_layer, output_layer in zip(input_stack, output_stack):
             res_dict = {}
-            generator = zip(input_layer, output_layer)
-            for input_data_source, output_data_source in generator:
-                for input_info in input_data_source:
-                    var_name = input_info[0]
-                    var_type = input_info[1]
+            for input_info in input_layer:
+                var_name = input_info[0]
+                var_type = input_info[1]
 
-                    if var_type in res_dict:
-                        res_dict[var_type].append(var_name)
-                    else:
-                        res_dict[var_type] = [var_name]
+                if var_type in res_dict:
+                    res_dict[var_type].append(var_name)
+                else:
+                    res_dict[var_type] = [var_name]
 
-                for output_info in output_data_source:
-                    var_name = output_info[0]
-                    var_type = output_info[1]
+            for output_info in output_layer:
+                var_name = output_info[0]
+                var_type = output_info[1]
 
-                    if var_type in res_dict:
-                        res_dict[var_type].append(var_name)
-                    else:
-                        res_dict[var_type] = [var_name]
+                if var_type in res_dict:
+                    res_dict[var_type].append(var_name)
+                else:
+                    res_dict[var_type] = [var_name]
 
             res.append(res_dict)
         return res
@@ -182,9 +178,8 @@ class VariableNamesRegistry(HasStrictTraits):
     def _get_data_source_names(self, stack):
         res = []
         for layer in stack:
-            for info in layer:
-                res.extend([value for value in info
-                            if value not in res])
+            res.extend([value for value in layer
+                        if value not in res])
         return res
 
     @on_trait_change(
@@ -236,11 +231,11 @@ class VariableNamesRegistry(HasStrictTraits):
                 input_types = [slot.type for slot in input_slots]
                 output_types = [slot.type for slot in output_slots]
 
-                input_stack_entry_for_layer.append([
+                input_stack_entry_for_layer.extend([
                     (name, type, data_source_model) for name, type
                     in zip(input_names, input_types) if name != ''
                 ])
-                output_stack_entry_for_layer.append([
+                output_stack_entry_for_layer.extend([
                     (name, type, data_source_model) for name, type
                     in zip(output_names, output_types) if name != ''
                 ])

--- a/force_wfmanager/utils/variable_names_registry.py
+++ b/force_wfmanager/utils/variable_names_registry.py
@@ -4,7 +4,9 @@ from traits.api import (
     HasStrictTraits, List, Instance, on_trait_change, Property,
     cached_property, Dict, Tuple)
 
-from force_bdss.api import Identifier, Workflow, BaseDataSourceModel
+from force_bdss.api import (
+    Identifier, Workflow, BaseDataSourceModel, InputSlotInfo
+)
 from force_bdss.local_traits import CUBAType
 
 log = logging.getLogger(__name__)
@@ -28,11 +30,11 @@ class VariableNamesRegistry(HasStrictTraits):
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the input variables produced by that execution layer
-    data_source_input = Tuple(Identifier, CUBAType, BaseDataSourceModel)
+    data_source_input = Tuple(Identifier, CUBAType)
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the output variables produced by that execution layer
-    data_source_output = Tuple(Identifier, CUBAType, BaseDataSourceModel)
+    data_source_output = Tuple(Identifier, CUBAType)
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the input variables produced by that execution layer
@@ -123,6 +125,14 @@ class VariableNamesRegistry(HasStrictTraits):
         output_stack = self.available_output_variables_stack
         input_stack = self.available_input_variables_stack
         variables = []
+
+        parameter_names = []
+        if self.workflow.mco is not None:
+            for parameter in self.workflow.mco.parameters:
+                parameter_names = []
+                parameter_names.append(parameter.name)
+
+        variables.append(parameter_names)
 
         for input_layer, output_layer in zip(input_stack, output_stack):
             layer_variables = []
@@ -232,11 +242,11 @@ class VariableNamesRegistry(HasStrictTraits):
                 output_types = [slot.type for slot in output_slots]
 
                 input_stack_entry_for_layer.extend([
-                    (name, type, data_source_model) for name, type
+                    (name, type) for name, type
                     in zip(input_names, input_types) if name != ''
                 ])
                 output_stack_entry_for_layer.extend([
-                    (name, type, data_source_model) for name, type
+                    (name, type) for name, type
                     in zip(output_names, output_types) if name != ''
                 ])
 

--- a/force_wfmanager/utils/variable_names_registry.py
+++ b/force_wfmanager/utils/variable_names_registry.py
@@ -4,7 +4,7 @@ from traits.api import (
     HasStrictTraits, List, Instance, on_trait_change, Property,
     cached_property, Dict, Tuple)
 
-from force_bdss.api import Identifier, Workflow
+from force_bdss.api import Identifier, Workflow, BaseDataSourceModel
 from force_bdss.local_traits import CUBAType
 
 log = logging.getLogger(__name__)
@@ -28,11 +28,11 @@ class VariableNamesRegistry(HasStrictTraits):
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the input variables produced by that execution layer
-    data_source_input = List(Tuple(Identifier, CUBAType))
+    data_source_input = List(Tuple(Identifier, CUBAType, BaseDataSourceModel))
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the output variables produced by that execution layer
-    data_source_output = List(Tuple(Identifier, CUBAType))
+    data_source_output = List(Tuple(Identifier, CUBAType, BaseDataSourceModel))
 
     #: For each execution layer, there will be a list of (name, type) pairs
     #: representing the input variables produced by that execution layer
@@ -237,11 +237,11 @@ class VariableNamesRegistry(HasStrictTraits):
                 output_types = [slot.type for slot in output_slots]
 
                 input_stack_entry_for_layer.append([
-                    (name, type) for name, type
+                    (name, type, data_source_model) for name, type
                     in zip(input_names, input_types) if name != ''
                 ])
                 output_stack_entry_for_layer.append([
-                    (name, type) for name, type
+                    (name, type, data_source_model) for name, type
                     in zip(output_names, output_types) if name != ''
                 ])
 


### PR DESCRIPTION
This PR further builds on work in #313 to improve UX and design aspects of the WfManager, working towards a graphical representation of the `Workflow`, as suggested in #282.

It addresses parts of #307 and is linked to #219 

## Work Done

1. `Variable` class defined in `variable_names_registry.py`, which acts as a layer of abstraction between the `DataSource` traits and those chosen as KPIs and parameters
2. Attribute `VariableNameRegistry.variable_registry` is a dictionary containing `Variable` objects that refer to input/output slots on the `DataSources`. Consequently, the names of each variable have persistence and can be tracked if they are changed. Additionally, it allows for the same input variable to be referenced multiple times in the `DataSource` slots, but dealt with as a single entity in the MCO.
3. Traits on `KPISpecification` and `MCOParameter` objects should now be automatically updated if these are changed on the corresponding `DataSources`
4. `MCOOptionsModelView` classes now contain `selected_variable` and `available_variable` traits, rather than `_combobox_values`. Consequently, their views now use `InstanceEditors` rather than `EnumEditors`.


## Know Issues
- Error message handling from `Variable` class needs to be hooked up to `WorkflowTree`
- `VariableNamesRegistry` has redundant methods that could be removed / replaced
## Future Work

- (Ongoing from #313) Allow the user to either enter new `DataSourceModel` variable names, or choose from existing input / output slot values.