### PR TITLE
Bug fix to KPI name options

### DIFF
--- a/force_wfmanager/ui/setup/mco/kpi_specification_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_view.py
@@ -132,11 +132,9 @@ class KPISpecificationView(BaseMCOOptionsView):
         kpi_name_options = []
         if self.variable_names_registry is not None:
             outputs = self.variable_names_registry.data_source_outputs
-            inputs = self.variable_names_registry.data_source_inputs
 
             kpi_name_options += (
-                [output_ for output_ in outputs
-                 if output_ not in inputs]
+                [output_ for output_ in outputs]
             )
 
         return kpi_name_options


### PR DESCRIPTION
In #313 the variables that were able to be selected in the UI as KPIs were restricted to output variables that were not consumed during the workflow. Therefore they could not also appear as input variables.

This was intended to simplify the UI, considering that most use case KPIs tended to be output variables produced at the end of the workflow process. However, it also restricts the possibility of optimising an intermediate variable as a KPI, which also has valid possible use cases, including the `enthought-example` plugin. 

This PR includes a simple fix to allow the user to choose between all output variables generated by `DataSource`s as possible KPIs.
