### PR TITLE
ENH: Refactor DataSourceView to reflect changes in force-bbss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -branch enh/refactor_slots
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/force_wfmanager/tests/probe_classes.py
+++ b/force_wfmanager/tests/probe_classes.py
@@ -4,6 +4,9 @@ from envisage.ui.tasks.tasks_plugin import TasksPlugin
 from traits.trait_types import Int
 
 from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
+from force_bdss.tests.probe_classes.data_source import (
+    ProbeDataSourceModel
+)
 from force_bdss.tests.probe_classes.factory_registry import (
     ProbeFactoryRegistry
 )
@@ -46,6 +49,6 @@ class ProbeWfManager(WfManager):
         self.run = self._create_windows
 
 
-class ProbeDataSourceModel(BaseDataSourceModel):
+class ProbeDataSourceModelDescription(ProbeDataSourceModel):
 
     test_trait = Int(13, desc='Test trait')

--- a/force_wfmanager/tests/probe_classes.py
+++ b/force_wfmanager/tests/probe_classes.py
@@ -3,7 +3,6 @@ from envisage.ui.tasks.tasks_plugin import TasksPlugin
 
 from traits.trait_types import Int
 
-from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
 from force_bdss.tests.probe_classes.data_source import (
     ProbeDataSourceModel
 )

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -98,15 +98,11 @@ class DataSourceView(HasTraits):
     #: The human readable name of the data source
     label = Unicode()
 
-    #: evaluator object, used to generate slots containing type and description
-    # of each variable (shouldn't be touched)
-    _data_source = Instance(BaseDataSource)
-
     #: Input slots representation for the table editor
-    input_slots_representation = List(InputSlotRow)
+    input_slot_rows = List(InputSlotRow)
 
     #: Output slots representation for the table editor
-    output_slots_representation = List(OutputSlotRow)
+    output_slot_rows = List(OutputSlotRow)
 
     # --------------------
     # Dependent Attributes
@@ -117,9 +113,9 @@ class DataSourceView(HasTraits):
     selected_slot_row = Instance(TableRow)
 
     #: Event to request a verification check on the workflow
-    #: Listens to: :attr:`input_slots_representation.name
-    #: <input_slots_representation>`, :attr:`output_slots_representation.name
-    #: <output_slots_representation>`
+    #: Listens to: :attr:`input_slot_rows.name
+    #: <input_slot_rows>`, :attr:`output_slot_rows.name
+    #: <output_slot_rows>`
     verify_workflow_event = Event()
 
     #: Defines if the evaluator is valid or not. Updated by
@@ -148,12 +144,12 @@ class DataSourceView(HasTraits):
         VGroup(
             VGroup(
                 Item(
-                    "input_slots_representation",
+                    "input_slot_rows",
                     label="Input variables",
                     editor=slots_editor,
                 ),
                 Item(
-                    "output_slots_representation",
+                    "output_slot_rows",
                     label="Output variables",
                     editor=slots_editor,
                 ),
@@ -181,9 +177,6 @@ class DataSourceView(HasTraits):
     def _label_default(self):
         return get_factory_name(self.model.factory)
 
-    def __data_source_default(self):
-        return self.model.factory.create_data_source()
-
     # -------------------
     #     Listeners
     # -------------------
@@ -204,8 +197,8 @@ class DataSourceView(HasTraits):
         return SLOT_DESCRIPTION.format(row_type, type_text, idx, description)
 
     @on_trait_change(
-        'input_slots_representation.[model.[name,type]],'
-        'output_slots_representation.[model.[name,type]]'
+        'input_slot_rows.[model.[name,type]],'
+        'output_slot_rows.[model.[name,type]]'
     )
     def data_source_change(self):
         """Fires :func:`verify_workflow_event` when an input slot or output
@@ -218,12 +211,12 @@ class DataSourceView(HasTraits):
         """ Fill the tables rows according to input_slots and output_slots
         needed by the evaluator and the model slot values """
 
-        self.input_slots_representation = [
+        self.input_slot_rows = [
             InputSlotRow(model=model, index=index)
             for index, model in enumerate(self.model.input_slot_info)
         ]
 
-        self.output_slots_representation = [
+        self.output_slot_rows = [
             OutputSlotRow(model=model, index=index)
             for index, model in enumerate(self.model.output_slot_info)
         ]

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -27,18 +27,8 @@ class TableRow(HasStrictTraits):
     #: Model of the evaluator
     model = Instance(HasStrictTraits)
 
-    #: Type of the slot
-    type = Unicode()
-
     #: Index of the slot in the slot list
     index = Int()
-
-    # ------------------
-    # Regular Attributes
-    # ------------------
-
-    #: A human readable description of the slot
-    description = Unicode()
 
 
 class InputSlotRow(TableRow):
@@ -74,8 +64,8 @@ slots_editor = TableEditor(
     configurable=False,
     selected="selected_slot_row",
     columns=[
-        ObjectColumn(name="index", label="", editable=False),
-        ObjectColumn(name="type", label="Type", editable=False),
+        ObjectColumn(name="model.index", label="", editable=False),
+        ObjectColumn(name="model.type", label="Type", editable=False),
         ObjectColumn(name="model.name", label="Variable Name",
                      editable=True, editor=name_editor),
     ]
@@ -182,7 +172,7 @@ class DataSourceView(HasTraits):
     def __init__(self, *args, **kwargs):
         super(DataSourceView, self).__init__(*args, **kwargs)
         # Performs private method to set up slots tables on instantiation
-        self._create_slots_tables()
+        self._update_slots_tables()
 
     # -------------------
     #     Defaults
@@ -205,8 +195,8 @@ class DataSourceView(HasTraits):
             return DEFAULT_MESSAGE
 
         idx = self.selected_slot_row.index
-        row_type = self.selected_slot_row.type
-        description = self.selected_slot_row.description
+        row_type = self.selected_slot_row.model.type
+        description = self.selected_slot_row.model.description
 
         type_text = (
             "Input" if isinstance(self.selected_slot_row, InputSlotRow)
@@ -214,8 +204,8 @@ class DataSourceView(HasTraits):
         return SLOT_DESCRIPTION.format(row_type, type_text, idx, description)
 
     @on_trait_change(
-        'input_slots_representation.[model.name,type],'
-        'output_slots_representation.[model.name,type]'
+        'input_slots_representation.[model.[name,type]],'
+        'output_slots_representation.[model.[name,type]]'
     )
     def data_source_change(self):
         """Fires :func:`verify_workflow_event` when an input slot or output
@@ -225,104 +215,22 @@ class DataSourceView(HasTraits):
     # Changed Slots Functions
     @on_trait_change('model:changes_slots')
     def _update_slots_tables(self):
-        """ Update the tables of slots when a change on the model triggers a
-        change on the shape of the input/output slots"""
-        #: This synchronization maybe is something that should be moved to the
-        #: model.
-        self.input_slots_representation[:] = []
-        self.output_slots_representation[:] = []
+        """ Fill the tables rows according to input_slots and output_slots
+        needed by the evaluator and the model slot values """
 
-        input_slots, output_slots = self._data_source.slots(self.model)
-
-        #: Initialize the input slots
-        self.model.input_slot_info = [
-            InputSlotInfo(model=slot)
-            for slot in input_slots
+        self.input_slots_representation = [
+            InputSlotRow(model=model, index=index)
+            for index, model in enumerate(self.model.input_slot_info)
         ]
 
-        #: Initialize the output slots
-        self.model.output_slot_info = [
-            OutputSlotInfo(name='')
-            for _ in output_slots
+        self.output_slots_representation = [
+            OutputSlotRow(model=model, index=index)
+            for index, model in enumerate(self.model.output_slot_info)
         ]
-
-        self._fill_slot_rows(input_slots, output_slots)
 
     # -------------------
     #   Private Methods
     # -------------------
-
-    # Initialization
-    def _create_slots_tables(self):
-        """ Initialize the tables for editing the input and output slots
-
-        Raises
-        ------
-        RuntimeError:
-            If the input slots or output slots in the model are not of the
-            right length. This can come from a corrupted file.
-        """
-        input_slots, output_slots = self._data_source.slots(self.model)
-
-        # Initialize model.input_slot_info if not initialized yet
-        if len(self.model.input_slot_info) == 0:
-            self.model.input_slot_info = [
-                InputSlotInfo(name='') for _ in input_slots
-            ]
-
-        if len(self.model.input_slot_info) != len(input_slots):
-            raise RuntimeError(
-                "The number of input slots ({}) of the {} model doesn't match "
-                "the expected number of slots ({}). This is likely due to a "
-                "corrupted file."
-                .format(
-                    len(self.model.input_slot_info),
-                    type(self.model).__name__,
-                    len(input_slots)))
-
-        # Initialize model.output_slot_info if not initialized yet
-        if len(self.model.output_slot_info) == 0:
-            self.model.output_slot_info = [
-                OutputSlotInfo(name="") for _ in output_slots
-            ]
-
-        if len(self.model.output_slot_info) != len(output_slots):
-            raise RuntimeError(
-                "The number of output slots ({}) of the {} model doesn't "
-                "match the expected number of slots ({}). This is likely due "
-                "to a corrupted file."
-                .format(
-                    len(self.model.output_slot_info),
-                    type(self.model).__name__,
-                    len(output_slots)))
-
-        self._fill_slot_rows(input_slots, output_slots)
-
-    def _fill_slot_rows(self, input_slots, output_slots):
-        """ Fill the tables rows according to input_slots and output_slots
-        needed by the evaluator and the model slot values """
-
-        input_representations = []
-
-        for index, input_slot in enumerate(input_slots):
-            slot_representation = InputSlotRow(
-                model=self.model.input_slot_info[index],
-                index=index, type=input_slot.type,
-                description=input_slot.description)
-            input_representations.append(slot_representation)
-
-        self.input_slots_representation[:] = input_representations
-
-        output_representation = []
-
-        for index, output_slot in enumerate(output_slots):
-            slot_representation = OutputSlotRow(
-                model=self.model.output_slot_info[index],
-                index=index, type=output_slot.type,
-                description=output_slot.description)
-            output_representation.append(slot_representation)
-
-        self.output_slots_representation[:] = output_representation
 
     def _available_variables(self):
         """Returns the available variables for the containing execution layer

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -24,6 +24,9 @@ class TableRow(HasStrictTraits):
     # Required Attributes
     # -------------------
 
+    #: Model of the evaluator
+    model = Instance(HasStrictTraits)
+
     #: Type of the slot
     type = Unicode()
 
@@ -45,7 +48,7 @@ class InputSlotRow(TableRow):
     # Required Attributes
     # -------------------
 
-    #: Model of the evaluator
+    #: InputSlotInfo model of the evaluator
     model = Instance(InputSlotInfo)
 
 
@@ -56,25 +59,17 @@ class OutputSlotRow(TableRow):
     # Required Attributes
     # -------------------
 
-    #: Model of the evaluator
+    #: OutputSlotInfo model of the evaluator
     model = Instance(OutputSlotInfo)
 
 
-#: The TraitsUI editor used for :class:`InputSlotRow`
-input_slots_editor = TableEditor(
-    sortable=False,
-    configurable=False,
-    selected="selected_slot_row",
-    columns=[
-        ObjectColumn(name="index", label="", editable=False),
-        ObjectColumn(name="type", label="Type", editable=False),
-        ObjectColumn(name="model.name", label="Variable Name",
-                     editable=True),
-    ]
-)
+#: The TraitsUI editor used for :object:`TableRow.model.name`
+name_editor = TextEditor(auto_set=False,
+                         enter_set=True)
 
-#: The TraitsUI editor used for :class:`OutputSlotRow`
-output_slots_editor = TableEditor(
+#: The TraitsUI editor used for :class:`InputSlotRow`
+#: and :class:`OutputSlotRow`
+slots_editor = TableEditor(
     sortable=False,
     configurable=False,
     selected="selected_slot_row",
@@ -82,7 +77,7 @@ output_slots_editor = TableEditor(
         ObjectColumn(name="index", label="", editable=False),
         ObjectColumn(name="type", label="Type", editable=False),
         ObjectColumn(name="model.name", label="Variable Name",
-                     editable=True),
+                     editable=True, editor=name_editor),
     ]
 )
 
@@ -165,19 +160,19 @@ class DataSourceView(HasTraits):
                 Item(
                     "input_slots_representation",
                     label="Input variables",
-                    editor=input_slots_editor,
+                    editor=slots_editor,
                 ),
                 Item(
                     "output_slots_representation",
                     label="Output variables",
-                    editor=output_slots_editor,
-                )
+                    editor=slots_editor,
+                ),
             ),
             VGroup(
                 UReadonly(
                     "selected_slot_description",
                     editor=TextEditor(),
-                    ),
+                ),
                 label="Selected parameter description",
                 show_border=True
             ),

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -40,11 +40,11 @@ class TestDataSourceView(WfManagerBaseTestCase):
         self.workflow.mco.parameters[0].name = 'P2'
         self.assertEqual('P1', self.model_1.input_slot_info[0].name)
 
-        self.data_source_view.input_slots_representation[0].name = 'P2'
+        self.data_source_view.input_slots_representation[0].model.name = 'P2'
         self.assertEqual('P2', self.model_1.input_slot_info[0].name)
 
     def test_output_slot_update(self):
-        self.data_source_view.output_slots_representation[0].name = 'output'
+        self.data_source_view.output_slots_representation[0].model.name = 'output'
         self.assertEqual('output', self.model_1.output_slot_info[0].name)
 
     def test_bad_input_slots(self):
@@ -77,17 +77,17 @@ class TestDataSourceView(WfManagerBaseTestCase):
 
         self.assertEqual(
             'p1',
-            self.data_source_view.output_slots_representation[0].name
+            self.data_source_view.output_slots_representation[0].model.name
         )
         self.assertEqual(
             't1',
-            self.data_source_view.output_slots_representation[1].name
+            self.data_source_view.output_slots_representation[1].model.name
         )
 
         self.model_1.input_slot_info[0].name = 'P2'
         self.assertEqual(
             'P2',
-            self.data_source_view.input_slots_representation[0].name
+            self.data_source_view.input_slots_representation[0].model.name
         )
 
     def test_HTML_description(self):

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -47,30 +47,6 @@ class TestDataSourceView(WfManagerBaseTestCase):
         self.data_source_view.output_slots_representation[0].model.name = 'output'
         self.assertEqual('output', self.model_1.output_slot_info[0].name)
 
-    def test_bad_input_slots(self):
-        input_slots, _ = self.data_source.slots(self.model_1)
-
-        self.model_1.input_slot_info = [
-            InputSlotInfo(name='') for _ in range(len(input_slots) + 1) # noqa
-        ]
-
-        with self.assertRaisesRegex(RuntimeError, "input slots"):
-            DataSourceView(
-                model=self.model_1,
-                variable_names_registry=self.variable_names_registry)
-
-    def test_bad_output_slots(self):
-        _, output_slots = self.data_source.slots(self.model_1)
-
-        self.model_1.output_slot_info = [
-            OutputSlotInfo(name='')
-            for slot in range(len(output_slots) + 1)]
-
-        with self.assertRaisesRegex(RuntimeError, "output slots"):
-            DataSourceView(
-                model=self.model_1,
-                variable_names_registry=self.variable_names_registry)
-
     def test_update_table(self):
         self.model_1.output_slot_info[0].name = 'p1'
         self.model_1.output_slot_info[1].name = 't1'

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -21,18 +21,18 @@ class TestDataSourceView(WfManagerBaseTestCase):
     def test_init_data_source_view(self):
         self.assertEqual(
             2,
-            len(self.data_source_view.output_slots_representation))
+            len(self.data_source_view.output_slot_rows))
         self.assertEqual(
-            len(self.data_source_view.output_slots_representation),
+            len(self.data_source_view.output_slot_rows),
             len(self.model_1.output_slot_info))
 
     def test_evaluator_view_init(self):
         self.assertEqual("test_data_source", self.data_source_view.label)
         self.assertIsInstance(self.data_source_view.model, BaseDataSourceModel)
         self.assertEqual(
-            1, len(self.data_source_view.input_slots_representation))
+            1, len(self.data_source_view.input_slot_rows))
         self.assertEqual(
-            2, len(self.data_source_view.output_slots_representation))
+            2, len(self.data_source_view.output_slot_rows))
         self.assertEqual('P1', self.model_1.input_slot_info[0].name)
         self.assertEqual('', self.model_1.output_slot_info[0].name)
 
@@ -40,11 +40,11 @@ class TestDataSourceView(WfManagerBaseTestCase):
         self.workflow.mco.parameters[0].name = 'P2'
         self.assertEqual('P1', self.model_1.input_slot_info[0].name)
 
-        self.data_source_view.input_slots_representation[0].model.name = 'P2'
+        self.data_source_view.input_slot_rows[0].model.name = 'P2'
         self.assertEqual('P2', self.model_1.input_slot_info[0].name)
 
     def test_output_slot_update(self):
-        self.data_source_view.output_slots_representation[0].model.name = 'output'
+        self.data_source_view.output_slot_rows[0].model.name = 'output'
         self.assertEqual('output', self.model_1.output_slot_info[0].name)
 
     def test_update_table(self):
@@ -53,29 +53,29 @@ class TestDataSourceView(WfManagerBaseTestCase):
 
         self.assertEqual(
             'p1',
-            self.data_source_view.output_slots_representation[0].model.name
+            self.data_source_view.output_slot_rows[0].model.name
         )
         self.assertEqual(
             't1',
-            self.data_source_view.output_slots_representation[1].model.name
+            self.data_source_view.output_slot_rows[1].model.name
         )
 
         self.model_1.input_slot_info[0].name = 'P2'
         self.assertEqual(
             'P2',
-            self.data_source_view.input_slots_representation[0].model.name
+            self.data_source_view.input_slot_rows[0].model.name
         )
 
     def test_HTML_description(self):
         self.assertIn("No Item Selected",
                       self.data_source_view.selected_slot_description)
-        out_slot = self.data_source_view.output_slots_representation[0]
+        out_slot = self.data_source_view.output_slot_rows[0]
         self.data_source_view.selected_slot_row = out_slot
         self.assertIn("Output row 0",
                       self.data_source_view.selected_slot_description)
         self.assertIn("PRESSURE",
                       self.data_source_view.selected_slot_description)
-        in_slot = self.data_source_view.input_slots_representation[0]
+        in_slot = self.data_source_view.input_slot_rows[0]
         self.data_source_view.selected_slot_row = in_slot
         self.assertIn("Input row 0",
                       self.data_source_view.selected_slot_description)

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -1,4 +1,4 @@
-from force_bdss.api import (OutputSlotInfo, InputSlotInfo, BaseDataSourceModel)
+from force_bdss.api import BaseDataSourceModel
 
 from force_wfmanager.ui.setup.process.data_source_view import \
     DataSourceView

--- a/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
+++ b/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
@@ -1,6 +1,11 @@
 import unittest
 
-from force_bdss.tests.dummy_classes.data_source import DummyDataSourceModel
+from force_bdss.tests.dummy_classes.data_source import (
+    DummyDataSourceModel, DummyDataSourceFactory
+)
+from force_bdss.tests.dummy_classes.extension_plugin import (
+    DummyExtensionPlugin
+)
 from force_bdss.tests.probe_classes.data_source import (
     ProbeDataSourceFactory, ProbeDataSourceModel
 )
@@ -13,7 +18,7 @@ from force_wfmanager.tests.dummy_classes.dummy_model_info import (
     DummyModelInfo
 )
 from force_wfmanager.tests.probe_classes import (
-    ProbeDataSourceModel as ProbeDataSourceModelDescription
+    ProbeDataSourceModelDescription
 )
 from force_wfmanager.ui.setup.new_entity_creator import (
      NewEntityCreator
@@ -113,10 +118,15 @@ class TestNewEntityModel(unittest.TestCase):
 
     def test_description_non_editable_datasource(self):
 
-        model, _ = self._get_data_selector()
-        model.selected_factory = self.data_sources[0]
+        plugin = DummyExtensionPlugin()
+        factory = DummyDataSourceFactory(plugin)
+        model = NewEntityCreator(
+            factories=[factory]
+        )
+        model.selected_factory = factory
+
         # An empty DataSourceModel with no editable traits
-        model.model = DummyDataSourceModel(self.data_sources[0])
+        model.model = DummyDataSourceModel(factory)
         self.assertFalse(model._current_model_editable)
         self.assertIn("No description available",
                       model.model_description_HTML)


### PR DESCRIPTION
The PR requires force-h2020/force-bdss/pull/230

Since the synchronization between slot attributes on `BaseDataSource` and `BaseDataSourceModel` classes is now performed in the `force-bdss`, this PR removes unnecessary routines in `DataSourceView` that performed the same task.

Consequently, all attributes of a variable are contained in either a `InputSlotInfo` or `OutputSlotInfo` class, and so these traits are referenced directly in any `TableRow` TraitsUI handler that displays them.

Some unit tests that were breaking due to force-h2020/force-bdss/pull/230 have also been tidied up. Most notably, since each `BaseDataSourceModel` now instantiates an associated `BaseDataSource` upon initiation, it is no longer safe to mix subclasses of these. For example, a `DummyDataSourceModel` should not be instantiated using a `ProbeDataSourceFactory` that contains a reference to a `ProbeDataSource`, as it not guaranteed that the model class has the correct attributes to successfully call `probe_data_source.slots(dummy_model)`.