### PR TITLE
WfManager Updates to accompany Refactor of BDSS Application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git --branch enh/refactor-bdss-application
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git --branch enh/refactor-bdss-application
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/force_wfmanager/gui/run.py
+++ b/force_wfmanager/gui/run.py
@@ -7,8 +7,9 @@ from stevedore import extension
 from stevedore.exception import NoMatches
 from traits.api import push_exception_handler
 
-from force_bdss.factory_registry_plugin import FactoryRegistryPlugin
-
+from force_bdss.core_plugins.factory_registry_plugin import (
+    FactoryRegistryPlugin
+)
 from force_wfmanager.version import __version__
 from force_wfmanager.wfmanager import WfManager
 from force_wfmanager.plugins.wfmanager_plugin import WfManagerPlugin

--- a/force_wfmanager/plugins/tests/test_plugin_dialog.py
+++ b/force_wfmanager/plugins/tests/test_plugin_dialog.py
@@ -3,7 +3,7 @@ import testfixtures
 
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 
-from force_bdss.base_extension_plugin import BaseExtensionPlugin
+from force_bdss.core_plugins.base_extension_plugin import BaseExtensionPlugin
 from force_wfmanager.plugins.plugin_dialog import htmlformat, PluginDialog
 from force_wfmanager.tests.dummy_classes.dummy_model_info import (
     DummyModelInfo

--- a/force_wfmanager/ui/tests/test_custom_ui_plugin.py
+++ b/force_wfmanager/ui/tests/test_custom_ui_plugin.py
@@ -6,7 +6,8 @@ from envisage.ui.tasks.tasks_plugin import TasksPlugin
 from force_bdss.api import plugin_id
 from force_bdss.core_plugins.service_offer_plugin import \
     ServiceOfferExtensionPlugin
-from force_bdss.factory_registry_plugin import FactoryRegistryPlugin
+from force_bdss.core_plugins.factory_registry_plugin import \
+    FactoryRegistryPlugin
 
 from force_wfmanager.plugins.wfmanager_plugin import WfManagerPlugin
 from force_wfmanager.tests.dummy_classes.dummy_factory import DummyFactory


### PR DESCRIPTION
This PR implements minor changes that are required to accompany refactoring of `force-bdss`, performed in force-h2020/force-bdss/pull/220. Specifically, the relocation of all Envisage plugins to the `force_bdss.core_plugins` module

It should not be merged before force-h2020/force-bdss/pull/220