### PR TITLE
FIX: Removed broken factory.plugin.id reference

### DIFF
--- a/force_wfmanager/utils/variable_names_registry.py
+++ b/force_wfmanager/utils/variable_names_registry.py
@@ -230,7 +230,7 @@ class VariableNamesRegistry(HasStrictTraits):
                         "in plugin '{}'. This may indicate a programming "
                         "error in the plugin".format(
                             data_source_model.factory.id,
-                            data_source_model.factory.plugin.id))
+                            data_source_model.factory.plugin_id))
                     raise
 
                 input_types = [slot.type for slot in input_slots]


### PR DESCRIPTION
A broken reference to `factory.plugin.id` has been removed from the `VariableNamesRegistry.update_available_variables_stacks` method. This was previously missed in #331 as it only occurred during an exception that was not covered in the test suite.

It is also not advisable for a change handler to raise an exception, so creating a unit test for this case is not as beneficial as refactoring the code (taken care of in #329)