### PR TITLE
FIX: ZMQ Server event serialization / deserialization

### DIFF
--- a/force_wfmanager/server/event_deserializer.py
+++ b/force_wfmanager/server/event_deserializer.py
@@ -55,12 +55,9 @@ class EventDeserializer(object):
             raise DeserializerError("Unable to deserialize requested "
                                     "type {}".format(class_name))
 
-        if (cls is None or
-                not issubclass(cls, BaseDriverEvent) or
-                cls == BaseDriverEvent):
-
-            raise DeserializerError("Unable to deserialize requested "
-                                    "type {}".format(class_name))
+        if not issubclass(cls, BaseDriverEvent):
+            raise DeserializerError("Class {} is not a child of BaseDriverEvent"
+                                    " class".format(class_name))
 
         if "model_data" not in d:
             raise DeserializerError("Unable to find model data for "

--- a/force_wfmanager/server/event_deserializer.py
+++ b/force_wfmanager/server/event_deserializer.py
@@ -14,6 +14,7 @@ class EventDeserializer(object):
     If you want to extend events to contain non-native python
     objects, you must implement a better serializer/deserializer.
     """
+
     def deserialize(self, data):
         """Deserializes the appropriate object from the given data
 
@@ -40,34 +41,40 @@ class EventDeserializer(object):
         try:
             class_module = d["module"]
         except KeyError:
-            raise DeserializerError("Could not find module key in json "
-                                    "data.")
+            raise DeserializerError(
+                "Could not find module key in json " "data."
+            )
         try:
             class_name = d["type"]
         except KeyError:
-            raise DeserializerError("Could not find type key in json "
-                                    "data.")
+            raise DeserializerError("Could not find type key in json " "data.")
 
         try:
             module = importlib.import_module(class_module)
             cls = getattr(module, class_name)
         except AttributeError:
-            raise DeserializerError("Unable to deserialize requested "
-                                    "type {}".format(class_name))
+            raise DeserializerError(
+                "Unable to deserialize requested " "type {}".format(class_name)
+            )
 
         if not issubclass(cls, BaseDriverEvent):
-            raise DeserializerError("Class {} is not a child of BaseDriverEvent"
-                                    " class".format(class_name))
+            raise DeserializerError(
+                "Class {} is not a child of BaseDriverEvent"
+                " class".format(class_name)
+            )
 
         if "model_data" not in d:
-            raise DeserializerError("Unable to find model data for "
-                                    "type {}".format(class_name))
+            raise DeserializerError(
+                "Unable to find model data for " "type {}".format(class_name)
+            )
 
         model_data = d["model_data"]
         if cls == MCOProgressEvent:
             model_data["optimal_point"] = [
-                DataValue(**data) for data in model_data["optimal_point"]]
+                DataValue(**data) for data in model_data["optimal_point"]
+            ]
             model_data["optimal_kpis"] = [
-                DataValue(**data) for data in model_data["optimal_kpis"]]
+                DataValue(**data) for data in model_data["optimal_kpis"]
+            ]
 
         return cls(**model_data)

--- a/force_wfmanager/server/event_serializer.py
+++ b/force_wfmanager/server/event_serializer.py
@@ -13,6 +13,7 @@ class EventSerializer(object):
     Important: only basic python types are supported. If events start
     carrying more complex instances, this serializer will not be enough.
     """
+
     def serialize(self, event):
         """Serializes an event into a json string
 
@@ -27,15 +28,17 @@ class EventSerializer(object):
             Raises if :param event: is not a BaseDriverEvent
         """
         if not isinstance(event, BaseDriverEvent):
-            raise SerializerError("Cannot serialize classes not derived "
-                                  "from BaseDriverEvent")
+            raise SerializerError(
+                "Cannot serialize classes not derived " "from BaseDriverEvent"
+            )
         data = json.dumps(
-            {"module": event.__class__.__module__,
-             "type": event.__class__.__name__,
-             "model_data": pop_recursive(
-                 event.__getstate__(),
-                 "__traits_version__")
-             }
+            {
+                "module": event.__class__.__module__,
+                "type": event.__class__.__name__,
+                "model_data": pop_recursive(
+                    event.__getstate__(), "__traits_version__"
+                ),
+            }
         )
 
         return data

--- a/force_wfmanager/server/event_serializer.py
+++ b/force_wfmanager/server/event_serializer.py
@@ -30,7 +30,8 @@ class EventSerializer(object):
             raise SerializerError("Cannot serialize classes not derived "
                                   "from BaseDriverEvent")
         data = json.dumps(
-            {"type": event.__class__.__name__,
+            {"module": event.__class__.__module__,
+             "type": event.__class__.__name__,
              "model_data": pop_recursive(
                  event.__getstate__(),
                  "__traits_version__")

--- a/force_wfmanager/server/tests/test_event_deserializer.py
+++ b/force_wfmanager/server/tests/test_event_deserializer.py
@@ -3,21 +3,25 @@ import unittest
 
 
 from force_wfmanager.server.event_deserializer import (
-    EventDeserializer, DeserializerError)
+    EventDeserializer,
+    DeserializerError,
+)
 
 from force_bdss.api import MCOStartEvent, MCOProgressEvent
 
 
 class TestEventDeserializer(unittest.TestCase):
     def test_instantiation(self):
-        data = json.dumps({
-            "module": "force_bdss.core_driver_events",
-            "type": "MCOStartEvent",
-            "model_data": {
-                "parameter_names": ["a", "b"],
-                "kpi_names": ["c", "d"]
+        data = json.dumps(
+            {
+                "module": "force_bdss.core_driver_events",
+                "type": "MCOStartEvent",
+                "model_data": {
+                    "parameter_names": ["a", "b"],
+                    "kpi_names": ["c", "d"],
+                },
             }
-        })
+        )
 
         event = EventDeserializer().deserialize(data)
         self.assertIsInstance(event, MCOStartEvent)
@@ -25,26 +29,17 @@ class TestEventDeserializer(unittest.TestCase):
         self.assertEqual(event.kpi_names, event.kpi_names)
 
     def test_progress_event_deserialize(self):
-        data = json.dumps({
-            "module": "force_bdss.core_driver_events",
-            "type": "MCOProgressEvent",
-            "model_data": {
-                "optimal_point": [
-                    {
-                        "value": 1.0
-                    },
-                    {
-                        "value": 2.0
-                    }
-                ],
-                "optimal_kpis": [
-                    {
-                        "value": 3.0
-                    },
-                ],
-                "weights": [1.0],
+        data = json.dumps(
+            {
+                "module": "force_bdss.core_driver_events",
+                "type": "MCOProgressEvent",
+                "model_data": {
+                    "optimal_point": [{"value": 1.0}, {"value": 2.0}],
+                    "optimal_kpis": [{"value": 3.0}],
+                    "weights": [1.0],
+                },
             }
-        })
+        )
 
         event = EventDeserializer().deserialize(data)
         self.assertIsInstance(event, MCOProgressEvent)
@@ -63,29 +58,23 @@ class TestEventDeserializer(unittest.TestCase):
                 "type": "Foo",
                 "model_data": {
                     "parameter_names": ["a", "b"],
-                    "kpi_names": ["c", "d"]
-                }
+                    "kpi_names": ["c", "d"],
+                },
             },
             {
                 "module": "force_bdss.core_driver_events",
                 "type": "BaseDeviceEvent",
-                "model_data": {
-                }
+                "model_data": {},
             },
             {
                 "module": "force_bdss.core.kpi_specification",
                 "type": "KPISpecification",
-                "model_data": {
-                }
+                "model_data": {},
             },
-            {
-                "module": "force_bdss.core.kpi_specification",
-                "model_data": {
-                }
-            },
+            {"module": "force_bdss.core.kpi_specification", "model_data": {}},
             {
                 "module": "force_bdss.core_driver_events",
-                "type": "BaseDriverEvent"
+                "type": "BaseDriverEvent",
             },
         ]
 

--- a/force_wfmanager/server/tests/test_event_deserializer.py
+++ b/force_wfmanager/server/tests/test_event_deserializer.py
@@ -11,6 +11,7 @@ from force_bdss.api import MCOStartEvent, MCOProgressEvent
 class TestEventDeserializer(unittest.TestCase):
     def test_instantiation(self):
         data = json.dumps({
+            "module": "force_bdss.core_driver_events",
             "type": "MCOStartEvent",
             "model_data": {
                 "parameter_names": ["a", "b"],
@@ -25,6 +26,7 @@ class TestEventDeserializer(unittest.TestCase):
 
     def test_progress_event_deserialize(self):
         data = json.dumps({
+            "module": "force_bdss.core_driver_events",
             "type": "MCOProgressEvent",
             "model_data": {
                 "optimal_point": [
@@ -65,20 +67,27 @@ class TestEventDeserializer(unittest.TestCase):
                 }
             },
             {
+                "module": "force_bdss.core_driver_events",
                 "type": "BaseDeviceEvent",
                 "model_data": {
                 }
             },
             {
+                "module": "force_bdss.core.kpi_specification",
+                "type": "KPISpecification",
                 "model_data": {
                 }
             },
             {
-                "type": "MCOStartEvent"
+                "module": "force_bdss.core.kpi_specification",
+                "model_data": {
+                }
             },
             {
-                "type": "MCOStartEvent"
-            }]
+                "module": "force_bdss.core_driver_events",
+                "type": "BaseDriverEvent"
+            },
+        ]
 
         for case in invalid_cases:
             with self.assertRaises(DeserializerError):

--- a/force_wfmanager/server/tests/test_event_serializer.py
+++ b/force_wfmanager/server/tests/test_event_serializer.py
@@ -2,16 +2,15 @@ import unittest
 import json
 
 from force_bdss.api import MCOStartEvent
-from force_wfmanager.server.event_serializer import \
-    EventSerializer, SerializerError
+from force_wfmanager.server.event_serializer import (
+    EventSerializer,
+    SerializerError,
+)
 
 
 class TestEventSerializer(unittest.TestCase):
     def test_serialize(self):
-        event = MCOStartEvent(
-            parameter_names=["a", "b"],
-            kpi_names=["c", 'd']
-        )
+        event = MCOStartEvent(parameter_names=["a", "b"], kpi_names=["c", "d"])
 
         data = EventSerializer().serialize(event)
 
@@ -23,8 +22,8 @@ class TestEventSerializer(unittest.TestCase):
                 "model_data": {
                     "parameter_names": ["a", "b"],
                     "kpi_names": ["c", "d"],
-                }
-            }
+                },
+            },
         )
 
     def test_serialize_invalid_entity(self):

--- a/force_wfmanager/server/tests/test_event_serializer.py
+++ b/force_wfmanager/server/tests/test_event_serializer.py
@@ -18,6 +18,7 @@ class TestEventSerializer(unittest.TestCase):
         self.assertEqual(
             json.loads(data),
             {
+                "module": "force_bdss.core_driver_events",
                 "type": "MCOStartEvent",
                 "model_data": {
                     "parameter_names": ["a", "b"],

--- a/force_wfmanager/server/tests/test_zmq_server.py
+++ b/force_wfmanager/server/tests/test_zmq_server.py
@@ -168,6 +168,7 @@ class TestZMQServer(unittest.TestCase):
                 x.encode('utf-8')
                 for x in ["MESSAGE", "xxx", json.dumps(
                     {
+                        "module": "force_bdss.core_driver_events",
                         'type': 'MCOStartEvent',
                         'model_data': {}
                     })]]
@@ -253,6 +254,7 @@ class TestZMQServer(unittest.TestCase):
                 x.encode('utf-8')
                 for x in ["MESSAGE", "xxx", json.dumps(
                     {
+                        "module": "force_bdss.core_driver_events",
                         'type': 'MCOStartEvent',
                         'model_data': {}
                     })]]

--- a/force_wfmanager/server/tests/test_zmq_server.py
+++ b/force_wfmanager/server/tests/test_zmq_server.py
@@ -23,8 +23,10 @@ class MockPoller(object):
     def poll(self):
         while True:
             sockets_with_data = [
-                (s, "whatever event") for s in self.sockets
-                if s.data is not None]
+                (s, "whatever event")
+                for s in self.sockets
+                if s.data is not None
+            ]
 
             if len(sockets_with_data) != 0:
                 return sockets_with_data
@@ -116,7 +118,7 @@ class TestZMQServer(unittest.TestCase):
 
             yield server
 
-            server._inproc_socket.data = ''.encode('utf-8')
+            server._inproc_socket.data = "".encode("utf-8")
             wait_condition(lambda: server.state == ZMQServer.STATE_STOPPED)
 
     @contextlib.contextmanager
@@ -132,15 +134,18 @@ class TestZMQServer(unittest.TestCase):
             errors_received.append((err_type, err_msg))
 
         with mock.patch.object(
-                ZMQServer, "_get_poller") as mock_get_poller, \
-                mock.patch.object(
-                    ZMQServer, "_get_context") as mock_get_context:
+            ZMQServer, "_get_poller"
+        ) as mock_get_poller, mock.patch.object(
+            ZMQServer, "_get_context"
+        ) as mock_get_context:
 
             mock_get_poller.return_value = MockPoller()
             mock_context = mock.Mock()
-            mock_context.socket.side_effect = [mock_pub_socket,
-                                               mock_sync_socket,
-                                               mock_inproc_socket]
+            mock_context.socket.side_effect = [
+                mock_pub_socket,
+                mock_sync_socket,
+                mock_inproc_socket,
+            ]
             mock_get_context.return_value = mock_context
 
             server = ZMQServer(cb, err_cb)
@@ -152,32 +157,42 @@ class TestZMQServer(unittest.TestCase):
         errors = []
 
         with self.mock_started_server(events, errors) as server:
-            server._sync_socket.data = [x.encode('utf-8')
-                                        for x in ["HELLO", "xxx", "1"]]
+            server._sync_socket.data = [
+                x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+            ]
             wait_condition(lambda: server.state == ZMQServer.STATE_RECEIVING)
 
-            server._sync_socket.data = [x.encode('utf-8')
-                                        for x in ["GOODBYE", "xxx"]]
+            server._sync_socket.data = [
+                x.encode("utf-8") for x in ["GOODBYE", "xxx"]
+            ]
             wait_condition(lambda: server.state == ZMQServer.STATE_WAITING)
 
-            server._sync_socket.data = [x.encode('utf-8')
-                                        for x in ["HELLO", "xxx", "1"]]
+            server._sync_socket.data = [
+                x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+            ]
             wait_condition(lambda: server.state == ZMQServer.STATE_RECEIVING)
 
             server._pub_socket.data = [
-                x.encode('utf-8')
-                for x in ["MESSAGE", "xxx", json.dumps(
-                    {
-                        "module": "force_bdss.core_driver_events",
-                        'type': 'MCOStartEvent',
-                        'model_data': {}
-                    })]]
+                x.encode("utf-8")
+                for x in [
+                    "MESSAGE",
+                    "xxx",
+                    json.dumps(
+                        {
+                            "module": "force_bdss.core_driver_events",
+                            "type": "MCOStartEvent",
+                            "model_data": {},
+                        }
+                    ),
+                ]
+            ]
 
             wait_condition(lambda: len(events) == 1)
             self.assertIsInstance(events[0], MCOStartEvent)
 
-            server._sync_socket.data = [x.encode('utf-8')
-                                        for x in ["GOODBYE", "xxx"]]
+            server._sync_socket.data = [
+                x.encode("utf-8") for x in ["GOODBYE", "xxx"]
+            ]
             wait_condition(lambda: server.state == ZMQServer.STATE_WAITING)
 
     def test_error_conditions_waiting_sync(self):
@@ -185,22 +200,33 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR) as capture:
             with self.mock_started_server(events, errors) as server:
-                server._sync_socket.data = ["HELLO".encode('utf-8')]
+                server._sync_socket.data = ["HELLO".encode("utf-8")]
                 wait_condition(lambda: len(capture.records) == 1)
-                server._sync_socket.data = [x.encode('utf-8')
-                                            for x in ["WHATEVER", 'xxx', '3']]
+                server._sync_socket.data = [
+                    x.encode("utf-8") for x in ["WHATEVER", "xxx", "3"]
+                ]
                 wait_condition(lambda: len(capture.records) == 2)
-                server._sync_socket.data = [x.encode('utf-8')
-                                            for x in ["HELLO", 'xxx', '3']]
+                server._sync_socket.data = [
+                    x.encode("utf-8") for x in ["HELLO", "xxx", "3"]
+                ]
                 wait_condition(lambda: len(capture.records) == 3)
 
             capture.check(
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown request received ['HELLO']"),
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown msg request received WHATEVER"),
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown protocol received 3")
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown request received ['HELLO']",
+                ),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown msg request received WHATEVER",
+                ),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown protocol received 3",
+                ),
             )
 
     def test_error_conditions_receiving_sync(self):
@@ -208,24 +234,34 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR) as capture:
             with self.mock_started_server(events, errors) as server:
-                server._sync_socket.data = [x.encode('utf-8')
-                                            for x in ["HELLO", "xxx", "1"]]
+                server._sync_socket.data = [
+                    x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+                ]
                 wait_condition(
-                    lambda: server.state == ZMQServer.STATE_RECEIVING)
+                    lambda: server.state == ZMQServer.STATE_RECEIVING
+                )
 
-                server._sync_socket.data = [x.encode('utf-8')
-                                            for x in ["HELLO", 'xxx', '1']]
+                server._sync_socket.data = [
+                    x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+                ]
                 wait_condition(lambda: len(capture.records) == 1)
 
-                server._sync_socket.data = [x.encode('utf-8')
-                                            for x in ["HELLO", 'xxx']]
+                server._sync_socket.data = [
+                    x.encode("utf-8") for x in ["HELLO", "xxx"]
+                ]
                 wait_condition(lambda: len(capture.records) == 2)
 
             capture.check(
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown request received ['HELLO', 'xxx', '1']"),
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown msg request received HELLO"),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown request received ['HELLO', 'xxx', '1']",
+                ),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown msg request received HELLO",
+                ),
             )
 
     def test_error_conditions_waiting_pub(self):
@@ -233,33 +269,45 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR) as capture:
             with self.mock_started_server(events, errors) as server:
-                server._pub_socket.data = [x.encode('utf-8')
-                                           for x in ["HELLO", "xxx", "1"]]
+                server._pub_socket.data = [
+                    x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+                ]
                 wait_condition(lambda: len(capture.records) == 1)
 
             capture.check(
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "State WAITING cannot handle pub data. Discarding."),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "State WAITING cannot handle pub data. Discarding.",
+                )
             )
 
     def test_socket_ordering(self):
         events = []
         errors = []
         with self.mock_started_server(events, errors) as server:
-            server._sync_socket.data = [x.encode('utf-8')
-                                        for x in ["HELLO", "xxx", "1"]]
+            server._sync_socket.data = [
+                x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+            ]
             wait_condition(lambda: server.state == ZMQServer.STATE_RECEIVING)
 
             server._pub_socket.data = [
-                x.encode('utf-8')
-                for x in ["MESSAGE", "xxx", json.dumps(
-                    {
-                        "module": "force_bdss.core_driver_events",
-                        'type': 'MCOStartEvent',
-                        'model_data': {}
-                    })]]
-            server._sync_socket.data = [x.encode('utf-8')
-                                        for x in ["GOODBYE", "xxx"]]
+                x.encode("utf-8")
+                for x in [
+                    "MESSAGE",
+                    "xxx",
+                    json.dumps(
+                        {
+                            "module": "force_bdss.core_driver_events",
+                            "type": "MCOStartEvent",
+                            "model_data": {},
+                        }
+                    ),
+                ]
+            ]
+            server._sync_socket.data = [
+                x.encode("utf-8") for x in ["GOODBYE", "xxx"]
+            ]
 
             wait_condition(lambda: len(events) == 1)
             wait_condition(lambda: server.state == ZMQServer.STATE_WAITING)
@@ -269,32 +317,44 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR) as capture:
             with self.mock_started_server(events, errors) as server:
-                server._sync_socket.data = [x.encode('utf-8')
-                                            for x in ["HELLO", "xxx", "1"]]
+                server._sync_socket.data = [
+                    x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+                ]
                 wait_condition(
-                    lambda: server.state == ZMQServer.STATE_RECEIVING)
+                    lambda: server.state == ZMQServer.STATE_RECEIVING
+                )
 
-                server._pub_socket.data = [x.encode('utf-8')
-                                           for x in ["MESSAGE", "xxx"]]
+                server._pub_socket.data = [
+                    x.encode("utf-8") for x in ["MESSAGE", "xxx"]
+                ]
                 wait_condition(lambda: len(capture.records) == 1)
 
-                server._pub_socket.data = [x.encode('utf-8')
-                                           for x in ["WHATEVER", "xxx", ""]]
+                server._pub_socket.data = [
+                    x.encode("utf-8") for x in ["WHATEVER", "xxx", ""]
+                ]
                 wait_condition(lambda: len(capture.records) == 2)
 
-                server._pub_socket.data = [x.encode('utf-8')
-                                           for x in ["MESSAGE",
-                                                     "xxx",
-                                                     "bonkers"]]
+                server._pub_socket.data = [
+                    x.encode("utf-8") for x in ["MESSAGE", "xxx", "bonkers"]
+                ]
                 wait_condition(lambda: len(capture.records) == 3)
 
             capture.check(
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown request received ['MESSAGE', 'xxx']"),
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 "Unknown msg request received WHATEVER"),
-                ('force_wfmanager.server.zmq_server', 'ERROR',
-                 'Received invalid data. Discarding'),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown request received ['MESSAGE', 'xxx']",
+                ),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Unknown msg request received WHATEVER",
+                ),
+                (
+                    "force_wfmanager.server.zmq_server",
+                    "ERROR",
+                    "Received invalid data. Discarding",
+                ),
             )
 
     def test_server_error_on_connect(self):
@@ -302,18 +362,26 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR):
             with self.mock_server(events, errors) as server:
-                with mock.patch.object(MockSocket,
-                                       'bind_to_random_port') as rp:
+                with mock.patch.object(
+                    MockSocket, "bind_to_random_port"
+                ) as rp:
                     rp.side_effect = Exception("Boom")
 
                     server.start()
                     wait_condition(lambda: len(errors) != 0)
 
-        self.assertEqual(errors, [(ZMQServer.ERROR_TYPE_CRITICAL,
-                                   "Unable to setup server sockets: Boom.\n"
-                                   "The server is now stopped. You will be "
-                                   "unable to receive progress information "
-                                   "from the BDSS.")])
+        self.assertEqual(
+            errors,
+            [
+                (
+                    ZMQServer.ERROR_TYPE_CRITICAL,
+                    "Unable to setup server sockets: Boom.\n"
+                    "The server is now stopped. You will be "
+                    "unable to receive progress information "
+                    "from the BDSS.",
+                )
+            ],
+        )
         self.assertEqual(server.state, ZMQServer.STATE_STOPPED)
 
     def test_server_error_on_poller_register(self):
@@ -321,18 +389,25 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR):
             with self.mock_server(events, errors) as server:
-                with mock.patch.object(MockPoller, 'register') as register:
+                with mock.patch.object(MockPoller, "register") as register:
                     register.side_effect = Exception("Boom")
 
                     server.start()
                     wait_condition(lambda: len(errors) != 0)
 
-        self.assertEqual(errors, [(ZMQServer.ERROR_TYPE_CRITICAL,
-                                   "Unable to register sockets to poller: "
-                                   "Boom.\n"
-                                   "The server is now stopped. You will be "
-                                   "unable to receive progress information "
-                                   "from the BDSS.")])
+        self.assertEqual(
+            errors,
+            [
+                (
+                    ZMQServer.ERROR_TYPE_CRITICAL,
+                    "Unable to register sockets to poller: "
+                    "Boom.\n"
+                    "The server is now stopped. You will be "
+                    "unable to receive progress information "
+                    "from the BDSS.",
+                )
+            ],
+        )
         self.assertEqual(server.state, ZMQServer.STATE_STOPPED)
 
     def test_server_error_unable_to_poll(self):
@@ -340,18 +415,25 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR):
             with self.mock_server(events, errors) as server:
-                with mock.patch.object(MockPoller, 'poll') as poll:
+                with mock.patch.object(MockPoller, "poll") as poll:
                     poll.side_effect = Exception("Boom")
 
                     server.start()
                     wait_condition(lambda: len(errors) != 0)
 
-        self.assertEqual(errors, [(ZMQServer.ERROR_TYPE_CRITICAL,
-                                   "Unable to poll sockets: "
-                                   "Boom.\n"
-                                   "The server is now stopped. You will be "
-                                   "unable to receive progress information "
-                                   "from the BDSS.")])
+        self.assertEqual(
+            errors,
+            [
+                (
+                    ZMQServer.ERROR_TYPE_CRITICAL,
+                    "Unable to poll sockets: "
+                    "Boom.\n"
+                    "The server is now stopped. You will be "
+                    "unable to receive progress information "
+                    "from the BDSS.",
+                )
+            ],
+        )
         self.assertEqual(server.state, ZMQServer.STATE_STOPPED)
 
     def test_server_error_handler_failure(self):
@@ -359,17 +441,20 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR):
             with self.mock_server(events, errors) as server:
-                with mock.patch.object(MockSocket, 'send_multipart') as send:
+                with mock.patch.object(MockSocket, "send_multipart") as send:
                     send.side_effect = Exception("Boom")
 
                     server.start()
                     wait_condition(
-                        lambda: server.state == ZMQServer.STATE_WAITING)
+                        lambda: server.state == ZMQServer.STATE_WAITING
+                    )
 
-                    server._sync_socket.data = [x.encode('utf-8')
-                                                for x in ["HELLO", "xxx", "1"]]
+                    server._sync_socket.data = [
+                        x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+                    ]
                     wait_condition(
-                        lambda: server.state != ZMQServer.STATE_WAITING)
+                        lambda: server.state != ZMQServer.STATE_WAITING
+                    )
 
         self.assertEqual(errors[0][0], ZMQServer.ERROR_TYPE_CRITICAL)
         self.assertIn("Handler", errors[0][1])
@@ -380,15 +465,17 @@ class TestZMQServer(unittest.TestCase):
         errors = []
         with LogCapture(level=logging.ERROR):
             with self.mock_server(events, errors) as server:
-                with mock.patch.object(MockSocket, 'recv_multipart') as recv:
+                with mock.patch.object(MockSocket, "recv_multipart") as recv:
                     recv.side_effect = Exception("Boom")
 
                     server.start()
                     wait_condition(
-                        lambda: server.state == ZMQServer.STATE_WAITING)
+                        lambda: server.state == ZMQServer.STATE_WAITING
+                    )
 
-                    server._sync_socket.data = [x.encode('utf-8')
-                                                for x in ["HELLO", "xxx", "1"]]
+                    server._sync_socket.data = [
+                        x.encode("utf-8") for x in ["HELLO", "xxx", "1"]
+                    ]
                     wait_condition(lambda: len(errors) != 0)
 
         self.assertEqual(errors[0][0], ZMQServer.ERROR_TYPE_WARNING)


### PR DESCRIPTION
The ZMQ server method for serializing `BaseDriverEvent` instances as JSON files did not contain enough information for full deserialization, leading to a fragile implementation of the ZMQ server deserialization method.

Specifically, the module location of `BaseDriverEvent` classes and subclasses was determined by the deserialization method, and set to `force_bdss.api`. Therefore the ZMQ server was not able to pass any subclasses of `BaseDriverEvent` that may have been contributed by additional plugins and therefore not exist in the core `force-bdss` module.

In order to provide a more robust implementation, we include a `module` reference in the serialized JSON, as well as a way to import the `BaseDriverEvent` class from this reference using the `importlib` library in the deserialize method.

An additional tidy up of logic statements involved in the deserialization and relevant unit tests has also been carried out.