### PR TITLE
Workflow mco_model attribute name change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
-    - pushd force-bdss && git checkout maint/workflow-mco-rename
+    - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
-    - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
+    - pushd force-bdss && git checkout maint/workflow-mco-rename
+    - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:
     - edm run -- python -m ci install

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_view.py
@@ -15,14 +15,14 @@ class TestBaseMCOOptionsView(unittest.TestCase, UnittestTools):
     def setUp(self):
         self.registry = get_basic_variable_names_registry()
         self.workflow = self.registry.workflow
-        self.param1 = self.workflow.mco.parameters[0]
-        self.param2 = self.workflow.mco.parameters[1]
-        self.param3 = self.workflow.mco.parameters[2]
+        self.param1 = self.workflow.mco_model.parameters[0]
+        self.param2 = self.workflow.mco_model.parameters[1]
+        self.param3 = self.workflow.mco_model.parameters[2]
         self.data_source1 = self.workflow.execution_layers[0].data_sources[0]
         self.data_source2 = self.workflow.execution_layers[0].data_sources[1]
 
         self.mco_options_view = DummyBaseMCOOptionsView(
-            model=self.workflow.mco,
+            model=self.workflow.mco_model,
             variable_names_registry=self.registry
         )
 

--- a/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_view.py
@@ -15,15 +15,15 @@ class TestKPISpecificationView(unittest.TestCase, UnittestTools):
     def setUp(self):
         self.registry = get_basic_variable_names_registry()
         self.workflow = self.registry.workflow
-        self.param1 = self.workflow.mco.parameters[0]
-        self.param2 = self.workflow.mco.parameters[1]
-        self.param3 = self.workflow.mco.parameters[2]
+        self.param1 = self.workflow.mco_model.parameters[0]
+        self.param2 = self.workflow.mco_model.parameters[1]
+        self.param3 = self.workflow.mco_model.parameters[2]
         self.data_source1 = self.workflow.execution_layers[0].data_sources[0]
         self.data_source2 = self.workflow.execution_layers[0].data_sources[1]
-        self.workflow.mco.kpis.append(KPISpecification())
+        self.workflow.mco_model.kpis.append(KPISpecification())
 
         self.kpi_view = KPISpecificationView(
-            model=self.workflow.mco,
+            model=self.workflow.mco_model,
             variable_names_registry=self.registry
         )
 
@@ -48,14 +48,14 @@ class TestKPISpecificationView(unittest.TestCase, UnittestTools):
         )
         self.assertEqual('KPI', self.kpi_view.model_views[0].label)
 
-        self.workflow.mco.kpis[0].name = 'T1'
+        self.workflow.mco_model.kpis[0].name = 'T1'
 
         self.assertEqual(
             "KPI: T1 (MINIMISE)",
             self.kpi_view.model_views[0].label
         )
 
-        self.workflow.mco.kpis[0].objective = 'MAXIMISE'
+        self.workflow.mco_model.kpis[0].objective = 'MAXIMISE'
 
         self.assertEqual(
             "KPI: T1 (MAXIMISE)",
@@ -71,7 +71,7 @@ class TestKPISpecificationView(unittest.TestCase, UnittestTools):
             self.assertEqual('KPI', kpi_model_view.label)
 
         with self.assertTraitChanges(kpi_model_view, 'label', count=1):
-            self.workflow.mco.kpis[0].name = 'T1'
+            self.workflow.mco_model.kpis[0].name = 'T1'
             self.assertEqual('KPI: T1 (MINIMISE)', kpi_model_view.label)
 
     def test_add_kpi(self):
@@ -80,7 +80,7 @@ class TestKPISpecificationView(unittest.TestCase, UnittestTools):
         self.assertEqual(1, len(self.kpi_view.kpi_name_options))
 
         self.kpi_view._add_kpi_button_fired()
-        self.assertEqual(2, len(self.workflow.mco.kpis))
+        self.assertEqual(2, len(self.workflow.mco_model.kpis))
         self.assertEqual(2, len(self.kpi_view.model_views))
 
         kpi_model_view = self.kpi_view.model_views[1]
@@ -95,14 +95,14 @@ class TestKPISpecificationView(unittest.TestCase, UnittestTools):
         self.kpi_view.selected_model_view = kpi_model_view
         self.kpi_view._remove_kpi_button_fired()
 
-        self.assertEqual(0, len(self.workflow.mco.kpis))
+        self.assertEqual(0, len(self.workflow.mco_model.kpis))
         self.assertEqual(0, len(self.kpi_view.model_views))
         self.assertIsNone(self.kpi_view.selected_model_view)
 
         self.kpi_view._add_kpi_button_fired()
         self.kpi_view._add_kpi_button_fired()
         self.kpi_view._add_kpi_button_fired()
-        self.assertEqual(3, len(self.workflow.mco.kpis))
+        self.assertEqual(3, len(self.workflow.mco_model.kpis))
         self.assertEqual(self.kpi_view.model_views[2],
                          self.kpi_view.selected_model_view)
 
@@ -128,17 +128,17 @@ class TestKPISpecificationView(unittest.TestCase, UnittestTools):
     def test__kpi_names_check(self):
 
         self.data_source1.output_slot_info = [OutputSlotInfo(name='T1')]
-        self.workflow.mco.kpis[0].name = 'T1'
+        self.workflow.mco_model.kpis[0].name = 'T1'
         error_message = self.kpi_view.verify_model_names()
         self.assertEqual(0, len(error_message))
 
         self.data_source2.output_slot_info = [OutputSlotInfo(name='T2')]
         self.kpi_view._add_kpi_button_fired()
-        self.workflow.mco.kpis[1].name = 'T2'
+        self.workflow.mco_model.kpis[1].name = 'T2'
         error_message = self.kpi_view.verify_model_names()
         self.assertEqual(0, len(error_message))
 
-        self.workflow.mco.kpis[0].name = 'T2'
+        self.workflow.mco_model.kpis[0].name = 'T2'
         error_message = self.kpi_view.verify_model_names()
         self.assertEqual(1, len(error_message))
         self.assertIn(

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_view.py
@@ -15,14 +15,14 @@ class TestMCOParameterView(unittest.TestCase, UnittestTools):
     def setUp(self):
         self.registry = get_basic_variable_names_registry()
         self.workflow = self.registry.workflow
-        self.param1 = self.workflow.mco.parameters[0]
-        self.param2 = self.workflow.mco.parameters[1]
-        self.param3 = self.workflow.mco.parameters[2]
+        self.param1 = self.workflow.mco_model.parameters[0]
+        self.param2 = self.workflow.mco_model.parameters[1]
+        self.param3 = self.workflow.mco_model.parameters[2]
         self.data_source1 = self.workflow.execution_layers[0].data_sources[0]
         self.data_source2 = self.workflow.execution_layers[0].data_sources[1]
 
         self.parameter_view = MCOParameterView(
-            model=self.workflow.mco,
+            model=self.workflow.mco_model,
             variable_names_registry=self.registry
         )
 
@@ -57,7 +57,7 @@ class TestMCOParameterView(unittest.TestCase, UnittestTools):
 
         self.parameter_view._add_parameter_button_fired()
 
-        self.assertEqual(4, len(self.workflow.mco.parameters))
+        self.assertEqual(4, len(self.workflow.mco_model.parameters))
         self.assertEqual(4, len(self.parameter_view.model_views))
 
         parameter_model_view = self.parameter_view.model_views[3]
@@ -71,7 +71,7 @@ class TestMCOParameterView(unittest.TestCase, UnittestTools):
         )
 
         self.parameter_view._dclick_add_parameter(None)
-        self.assertEqual(5, len(self.workflow.mco.parameters))
+        self.assertEqual(5, len(self.workflow.mco_model.parameters))
 
     def test_remove_parameter(self):
 
@@ -79,7 +79,7 @@ class TestMCOParameterView(unittest.TestCase, UnittestTools):
         self.parameter_view.selected_model_view = parameter_model_view
         self.parameter_view._remove_parameter_button_fired()
 
-        self.assertEqual(2, len(self.workflow.mco.parameters))
+        self.assertEqual(2, len(self.workflow.mco_model.parameters))
         self.assertEqual(2, len(self.parameter_view.model_views))
         self.assertEqual(
             self.parameter_view.selected_model_view,
@@ -98,12 +98,12 @@ class TestMCOParameterView(unittest.TestCase, UnittestTools):
         self.data_source1.input_slot_info = [InputSlotInfo(name='T1')]
         self.data_source2.input_slot_info = [InputSlotInfo(name='T2')]
 
-        self.workflow.mco.parameters[0].name = 'T1'
-        self.workflow.mco.parameters[1].name = 'T2'
+        self.workflow.mco_model.parameters[0].name = 'T1'
+        self.workflow.mco_model.parameters[1].name = 'T2'
         error_message = self.parameter_view.verify_model_names()
         self.assertEqual(0, len(error_message))
 
-        self.workflow.mco.parameters[0].name = 'T2'
+        self.workflow.mco_model.parameters[0].name = 'T2'
         error_message = self.parameter_view.verify_model_names()
         self.assertIn(
             'Two or more Parameters have a duplicate name',

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_view.py
@@ -30,7 +30,7 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
         )
 
         self.mco_view = MCOView(
-            model=self.workflow.mco,
+            model=self.workflow.mco_model,
             variable_names_registry=self.variable_names_registry
         )
 
@@ -128,7 +128,7 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
 
         old_parameter_view = self.mco_view.parameter_view
         new_parameter_view = MCOParameterView(
-            model=self.workflow.mco
+            model=self.workflow.mco_model
         )
 
         self.mco_view.parameter_view = new_parameter_view
@@ -144,7 +144,7 @@ class TestMCOView(WfManagerBaseTestCase, UnittestTools):
 
         old_kpi_view = self.mco_view.kpi_view
         new_kpi_view = KPISpecificationView(
-            model=self.workflow.mco
+            model=self.workflow.mco_model
         )
 
         self.mco_view.kpi_view = new_kpi_view

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -37,7 +37,7 @@ class TestDataSourceView(WfManagerBaseTestCase):
         self.assertEqual('', self.model_1.output_slot_info[0].name)
 
     def test_input_slot_update(self):
-        self.workflow.mco.parameters[0].name = 'P2'
+        self.workflow.mco_model.parameters[0].name = 'P2'
         self.assertEqual('P1', self.model_1.input_slot_info[0].name)
 
         self.data_source_view.input_slots_representation[0].name = 'P2'

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -44,7 +44,7 @@ class TestSetupPane(GuiTestAssistant, TestCase):
         #: Set up workflow containing 1 execution layer with 1
         #: data sources and 2 MCO parameters
         self.workflow = Workflow(
-            mco=self.mco_model,
+            mco_model=self.mco_model,
             execution_layers=[self.execution_layer]
         )
 

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -1,33 +1,35 @@
 from unittest import mock, TestCase
 
 from force_bdss.api import (
-    ExecutionLayer, Workflow, BaseMCOModel, KPISpecification,
-    VerifierError
+    ExecutionLayer,
+    Workflow,
+    BaseMCOModel,
+    KPISpecification,
+    VerifierError,
 )
 
 from force_wfmanager.tests.dummy_classes.dummy_mco_options_view import (
-    DummyBaseMCOOptionsView
+    DummyBaseMCOOptionsView,
 )
 from force_wfmanager.ui.setup.system_state import SystemState
 from force_wfmanager.ui.setup.tests.wfmanager_base_test_case import (
-    WfManagerBaseTestCase
+    WfManagerBaseTestCase,
 )
 from force_wfmanager.ui.setup.workflow_tree import (
-    WorkflowTree, TreeNodeWithStatus, verifier_check
+    WorkflowTree,
+    TreeNodeWithStatus,
+    verifier_check,
 )
 
 
 class TestWorkflowTree(WfManagerBaseTestCase):
-
     def setUp(self):
         super(TestWorkflowTree, self).setUp()
         data_sources = [
             self.factory_registry.data_source_factories[2].create_model(),
-            self.factory_registry.data_source_factories[3].create_model()
+            self.factory_registry.data_source_factories[3].create_model(),
         ]
-        execution_layer = ExecutionLayer(
-            data_sources=data_sources
-        )
+        execution_layer = ExecutionLayer(data_sources=data_sources)
         self.workflow.execution_layers.append(execution_layer)
         self.workflow.mco_model.kpis.append(KPISpecification())
 
@@ -35,17 +37,13 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.workflow_tree = WorkflowTree(
             model=self.workflow,
             _factory_registry=self.factory_registry,
-            system_state=self.system_state
+            system_state=self.system_state,
         )
 
     def test_ui_initialization(self):
 
-        self.assertEqual(
-            1, len(self.workflow_tree.workflow_view.mco_view)
-        )
-        self.assertEqual(
-            1, len(self.workflow_tree.workflow_view.process_view)
-        )
+        self.assertEqual(1, len(self.workflow_tree.workflow_view.mco_view))
+        self.assertEqual(1, len(self.workflow_tree.workflow_view.process_view))
         self.assertEqual(
             1, len(self.workflow_tree.workflow_view.communicator_view)
         )
@@ -57,54 +55,43 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         )
         self.assertEqual(2, len(process_view.execution_layer_views))
         self.assertEqual(
-            2, len(process_view.model.execution_layers[0]
-                   .data_sources))
-        self.assertEqual(
-            2,
-            len(process_view.execution_layer_views[0]
-                .data_source_views))
-
-        self.assertEqual(
-            self.system_state,
-            self.workflow_tree.system_state
+            2, len(process_view.model.execution_layers[0].data_sources)
         )
+        self.assertEqual(
+            2, len(process_view.execution_layer_views[0].data_source_views)
+        )
+
+        self.assertEqual(self.system_state, self.workflow_tree.system_state)
 
         self.assertIsNone(self.system_state.entity_creator)
         self.assertIsNone(self.system_state.add_new_entity)
 
     def test_workflow_selected(self):
 
-        self.workflow_tree.workflow_selected(
-            self.workflow_tree.workflow_view
-        )
-        self.assertEqual(
-            'Workflow', self.system_state.selected_factory_name
-        )
+        self.workflow_tree.workflow_selected(self.workflow_tree.workflow_view)
+        self.assertEqual("Workflow", self.system_state.selected_factory_name)
         self.assertIsNone(self.system_state.add_new_entity)
         self.assertIsNone(self.system_state.remove_entity)
         self.assertIsNone(self.system_state.entity_creator)
 
     def test_process_selected(self):
 
-        process_view = (
-            self.workflow_tree.workflow_view.process_view[0]
-        )
+        process_view = self.workflow_tree.workflow_view.process_view[0]
         self.workflow_tree.process_selected(process_view)
         self.assertEqual(
-            'Execution Layer', self.system_state.selected_factory_name
+            "Execution Layer", self.system_state.selected_factory_name
         )
         self.assertIsNotNone(self.system_state.add_new_entity)
         self.assertIsNone(self.system_state.remove_entity)
         self.assertIsNone(self.system_state.entity_creator)
 
     def test_execution_layer_selected(self):
-        execution_layer_view = (
-            self.workflow_tree.workflow_view.process_view[0]
-            .execution_layer_views[0]
-        )
+        execution_layer_view = self.workflow_tree.workflow_view.process_view[
+            0
+        ].execution_layer_views[0]
         self.workflow_tree.execution_layer_selected(execution_layer_view)
         self.assertEqual(
-            'Data Source', self.system_state.selected_factory_name
+            "Data Source", self.system_state.selected_factory_name
         )
         self.assertIsNotNone(self.system_state.add_new_entity)
         self.assertIsNotNone(self.system_state.remove_entity)
@@ -113,35 +100,28 @@ class TestWorkflowTree(WfManagerBaseTestCase):
     def test_data_source_selected(self):
         data_source_view = (
             self.workflow_tree.workflow_view.process_view[0]
-            .execution_layer_views[0].data_source_views[0]
+            .execution_layer_views[0]
+            .data_source_views[0]
         )
         self.workflow_tree.data_source_selected(data_source_view)
-        self.assertEqual(
-            'None', self.system_state.selected_factory_name
-        )
+        self.assertEqual("None", self.system_state.selected_factory_name)
         self.assertIsNone(self.system_state.add_new_entity)
         self.assertIsNotNone(self.system_state.remove_entity)
         self.assertIsNone(self.system_state.entity_creator)
 
     def test_mco_selected(self):
-        mco_view = (
-            self.workflow_tree.workflow_view.mco_view[0]
-        )
+        mco_view = self.workflow_tree.workflow_view.mco_view[0]
         self.workflow_tree.mco_selected(mco_view)
-        self.assertEqual(
-            'MCO', self.system_state.selected_factory_name
-        )
+        self.assertEqual("MCO", self.system_state.selected_factory_name)
         self.assertIsNotNone(self.system_state.add_new_entity)
         self.assertIsNone(self.system_state.remove_entity)
         self.assertIsNotNone(self.system_state.entity_creator)
 
     def test_mco_parameters_selected(self):
-        mco_view = (
-            self.workflow_tree.workflow_view.mco_view[0]
-        )
+        mco_view = self.workflow_tree.workflow_view.mco_view[0]
         self.workflow_tree.mco_parameters_selected(mco_view)
         self.assertEqual(
-            'MCO Parameters', self.system_state.selected_factory_name
+            "MCO Parameters", self.system_state.selected_factory_name
         )
 
         self.assertIsNone(self.system_state.add_new_entity)
@@ -149,13 +129,9 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.assertIsNone(self.system_state.entity_creator)
 
     def test_mco_kpis_selected(self):
-        mco_view = (
-            self.workflow_tree.workflow_view.mco_view[0]
-        )
+        mco_view = self.workflow_tree.workflow_view.mco_view[0]
         self.workflow_tree.mco_kpis_selected(mco_view)
-        self.assertEqual(
-            'MCO KPIs', self.system_state.selected_factory_name
-        )
+        self.assertEqual("MCO KPIs", self.system_state.selected_factory_name)
 
         self.assertIsNone(self.system_state.add_new_entity)
         self.assertIsNone(self.system_state.remove_entity)
@@ -167,22 +143,23 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         workflow_tree = WorkflowTree(
             model=workflow_no_mco,
             _factory_registry=self.factory_registry,
-            system_state=self.system_state)
+            system_state=self.system_state,
+        )
 
         self.assertIsNone(workflow_tree.workflow_view.model.mco_model)
         self.assertEqual(len(workflow_tree.workflow_view.mco_view), 0)
 
         workflow_tree.mco_selected(workflow_tree.workflow_view)
 
-        self.system_state.entity_creator.model = (
-            self.factory_registry.mco_factories[0].create_model()
-        )
+        mco_factory = self.factory_registry.mco_factories[0]
+        self.system_state.entity_creator.model = mco_factory.create_model()
         self.system_state.add_new_entity()
 
         self.assertIsNotNone(workflow_tree.workflow_view.model.mco_model)
         self.assertEqual(len(workflow_tree.workflow_view.mco_view), 1)
-        self.assertIsInstance(workflow_tree.workflow_view.model.mco_model,
-                              BaseMCOModel)
+        self.assertIsInstance(
+            workflow_tree.workflow_view.model.mco_model, BaseMCOModel
+        )
 
     def test_delete_mco(self):
 
@@ -199,140 +176,95 @@ class TestWorkflowTree(WfManagerBaseTestCase):
 
     def test_new_execution_layer(self):
 
-        process_view = (
-            self.workflow_tree.workflow_view.process_view[0]
-        )
+        process_view = self.workflow_tree.workflow_view.process_view[0]
         self.workflow_tree.process_selected(process_view)
 
         self.system_state.add_new_entity()
 
-        self.assertEqual(
-            3, len(process_view.execution_layer_views)
-        )
+        self.assertEqual(3, len(process_view.execution_layer_views))
 
     def test_delete_execution_layer(self):
-        process_view = (
-            self.workflow_tree.workflow_view.process_view[0]
-        )
-        first_execution_layer = (
-            process_view.execution_layer_views[0]
-        )
-        second_execution_layer = (
-            process_view.execution_layer_views[1]
-        )
+        process_view = self.workflow_tree.workflow_view.process_view[0]
+        first_execution_layer = process_view.execution_layer_views[0]
+        second_execution_layer = process_view.execution_layer_views[1]
 
         self.workflow_tree.execution_layer_selected(first_execution_layer)
 
         self.system_state.remove_entity()
 
-        self.assertEqual(
-            1, len(process_view.execution_layer_views))
-        self.assertEqual(
-            1, len(process_view.model.execution_layers))
+        self.assertEqual(1, len(process_view.execution_layer_views))
+        self.assertEqual(1, len(process_view.model.execution_layers))
 
         self.assertNotEqual(
-            first_execution_layer,
-            process_view.execution_layer_views[0]
+            first_execution_layer, process_view.execution_layer_views[0]
         )
         self.assertEqual(
             len(second_execution_layer.data_source_views),
-            len(process_view.execution_layer_views[0]
-                .data_source_views)
+            len(process_view.execution_layer_views[0].data_source_views),
         )
 
     def test_new_data_source(self):
-        process_view = (
-            self.workflow_tree.workflow_view.process_view[0]
-        )
-        execution_layer = (
-            process_view.execution_layer_views[0]
-        )
+        process_view = self.workflow_tree.workflow_view.process_view[0]
+        execution_layer = process_view.execution_layer_views[0]
 
         self.assertEqual(len(execution_layer.data_source_views), 2)
 
         self.workflow_tree.execution_layer_selected(execution_layer)
 
-        self.system_state.entity_creator.model = (
-            self.factory_registry.data_source_factories[0].create_model()
-        )
+        data_factory = self.factory_registry.data_source_factories[0]
+        self.system_state.entity_creator.model = data_factory.create_model()
 
         self.system_state.add_new_entity()
 
         self.assertEqual(len(execution_layer.data_source_views), 3)
 
     def test_delete_data_source(self):
-        process_view = (
-            self.workflow_tree.workflow_view.process_view[0]
-        )
-        data_source = (
-            process_view.execution_layer_views[0]
-            .data_source_views[0]
-        )
+        process_view = self.workflow_tree.workflow_view.process_view[0]
+        data_source = process_view.execution_layer_views[0].data_source_views[
+            0
+        ]
 
         self.workflow_tree.data_source_selected(data_source)
 
         self.system_state.remove_entity()
 
         self.assertEqual(
-            1,
-            len(process_view.execution_layer_views[0]
-                .data_source_views)
-            )
+            1, len(process_view.execution_layer_views[0].data_source_views)
+        )
         self.assertEqual(
-            1,
-            len(process_view.model.execution_layers[0]
-                .data_sources)
-            )
+            1, len(process_view.model.execution_layers[0].data_sources)
+        )
 
     def test_new_notification_listener(self):
-        communicator_view = (self.workflow_tree.workflow_view
-                             .communicator_view[0])
+        communicator_view = self.workflow_tree.workflow_view.communicator_view[
+            0
+        ]
 
-        self.assertEqual(
-            1, len(communicator_view.notification_listener_views)
-        )
-        self.assertEqual(
-            1, len(self.workflow.notification_listeners)
-        )
+        self.assertEqual(1, len(communicator_view.notification_listener_views))
+        self.assertEqual(1, len(self.workflow.notification_listeners))
 
         self.workflow_tree.communicator_selected(communicator_view)
-        self.system_state.entity_creator.model = (
-            self.factory_registry.notification_listener_factories[0]
-            .create_model()
-        )
+        factory = self.factory_registry.notification_listener_factories[0]
+        self.system_state.entity_creator.model = factory.create_model()
         self.system_state.add_new_entity()
 
         self.assertIsNotNone(self.system_state.entity_creator)
-        self.assertEqual(
-            2, len(communicator_view.notification_listener_views)
-        )
-        self.assertEqual(
-            2, len(self.workflow.notification_listeners)
-        )
+        self.assertEqual(2, len(communicator_view.notification_listener_views))
+        self.assertEqual(2, len(self.workflow.notification_listeners))
 
     def test_delete_notification_listener(self):
-        communicator_view = (self.workflow_tree.workflow_view
-                             .communicator_view[0])
-        self.assertEqual(
-            1, len(communicator_view.notification_listener_views)
-        )
-        self.assertEqual(
-            1, len(self.workflow.notification_listeners)
-        )
+        communicator_view = self.workflow_tree.workflow_view.communicator_view[
+            0
+        ]
+        self.assertEqual(1, len(communicator_view.notification_listener_views))
+        self.assertEqual(1, len(self.workflow.notification_listeners))
 
-        notification_listener_view = (communicator_view
-                                      .notification_listener_views[0])
-        self.workflow_tree.notification_listener_selected(
-            notification_listener_view
-        )
+        listener_view = communicator_view.notification_listener_views[0]
+        self.workflow_tree.notification_listener_selected(listener_view)
         self.system_state.remove_entity()
 
-        self.assertEqual(
-            0, len(communicator_view.notification_listener_views)
-        )
-        self.assertEqual(
-            0, len(self.workflow.notification_listeners)
-        )
+        self.assertEqual(0, len(communicator_view.notification_listener_views))
+        self.assertEqual(0, len(self.workflow.notification_listeners))
 
     def test_error_messaging(self):
 
@@ -346,24 +278,23 @@ class TestWorkflowTree(WfManagerBaseTestCase):
 
         data_source_view = (
             self.workflow_tree.workflow_view.process_view[0]
-            .execution_layer_views[0].data_source_views[0]
+            .execution_layer_views[0]
+            .data_source_views[0]
         )
-        data_source_view.model.output_slot_info[0].name = 'something'
+        data_source_view.model.output_slot_info[0].name = "something"
         self.system_state.selected_view = data_source_view
 
         self.assertIn(
             "An output variable has an undefined name",
-            self.workflow_tree.selected_error
+            self.workflow_tree.selected_error,
         )
 
     def test_mco_error_messaging_independence(self):
 
-        mco_view = (
-            self.workflow_tree.workflow_view.mco_view[0]
-        )
+        mco_view = self.workflow_tree.workflow_view.mco_view[0]
         self.assertIn(
             "A KPI is not named",
-            self.workflow_tree.workflow_view.error_message
+            self.workflow_tree.workflow_view.error_message,
         )
 
         self.assertFalse(mco_view.kpi_view.model_views[0].valid)
@@ -377,37 +308,40 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.system_state.selected_view = mco_view.parameter_view
         self.assertIn("No errors", self.workflow_tree.selected_error)
 
-        mco_view.parameter_view.model_views[0].model.name = ''
-        self.assertIn("An MCO parameter is not named",
-                      self.workflow_tree.selected_error)
-        self.assertIn("An MCO parameter has no type set",
-                      self.workflow_tree.selected_error)
+        mco_view.parameter_view.model_views[0].model.name = ""
+        self.assertIn(
+            "An MCO parameter is not named", self.workflow_tree.selected_error
+        )
+        self.assertIn(
+            "An MCO parameter has no type set",
+            self.workflow_tree.selected_error,
+        )
         self.assertFalse(mco_view.parameter_view.valid)
 
 
 class TestProcessElementNode(TestCase):
-
     def test_wfelement_node(self):
 
         wfelement_node = TreeNodeWithStatus()
         obj = mock.Mock()
         obj.valid = True
-        self.assertEqual(wfelement_node.get_icon(obj, False),
-                         'icons/valid.png')
+        self.assertEqual(
+            wfelement_node.get_icon(obj, False), "icons/valid.png"
+        )
         obj.valid = False
-        self.assertEqual(wfelement_node.get_icon(obj, False),
-                         'icons/invalid.png')
+        self.assertEqual(
+            wfelement_node.get_icon(obj, False), "icons/invalid.png"
+        )
 
 
 class TestVerifierCheck(TestCase):
-
     def setUp(self):
         self.view = DummyBaseMCOOptionsView()
         self.verifier_error = VerifierError(
             subject=self.view,
-            local_error='an error',
-            global_error='AN ERROR',
-            severity='error'
+            local_error="an error",
+            global_error="AN ERROR",
+            severity="error",
         )
         self.message_list = []
         self.send_to_parent = []
@@ -419,40 +353,52 @@ class TestVerifierCheck(TestCase):
         self.assertEqual(0, len(self.send_to_parent))
 
         verifier_check(
-            self.verifier_error, 'error', self.message_list,
-            self.send_to_parent, self.view)
+            self.verifier_error,
+            "error",
+            self.message_list,
+            self.send_to_parent,
+            self.view,
+        )
 
         self.assertFalse(self.view.valid)
         self.assertEqual(1, len(self.message_list))
-        self.assertEqual('an error', self.message_list[0])
+        self.assertEqual("an error", self.message_list[0])
         self.assertEqual(1, len(self.send_to_parent))
-        self.assertEqual('AN ERROR', self.send_to_parent[0])
+        self.assertEqual("AN ERROR", self.send_to_parent[0])
 
     def test_verifier_check_warning(self):
 
-        self.verifier_error.severity = 'warning'
-        self.verifier_error.local_error = 'a warning'
-        self.verifier_error.global_error = 'A WARNING'
+        self.verifier_error.severity = "warning"
+        self.verifier_error.local_error = "a warning"
+        self.verifier_error.global_error = "A WARNING"
 
         self.assertTrue(self.view.valid)
         self.assertEqual(0, len(self.message_list))
         self.assertEqual(0, len(self.send_to_parent))
 
         verifier_check(
-            self.verifier_error, 'error', self.message_list,
-            self.send_to_parent, self.view)
+            self.verifier_error,
+            "error",
+            self.message_list,
+            self.send_to_parent,
+            self.view,
+        )
 
         self.assertTrue(self.view.valid)
         self.assertEqual(1, len(self.message_list))
-        self.assertEqual('a warning', self.message_list[0])
+        self.assertEqual("a warning", self.message_list[0])
         self.assertEqual(0, len(self.send_to_parent))
 
         verifier_check(
-            self.verifier_error, 'warning', self.message_list,
-            self.send_to_parent, self.view)
+            self.verifier_error,
+            "warning",
+            self.message_list,
+            self.send_to_parent,
+            self.view,
+        )
 
         self.assertFalse(self.view.valid)
         self.assertEqual(1, len(self.message_list))
-        self.assertEqual('a warning', self.message_list[0])
+        self.assertEqual("a warning", self.message_list[0])
         self.assertEqual(1, len(self.send_to_parent))
-        self.assertEqual('A WARNING', self.send_to_parent[0])
+        self.assertEqual("A WARNING", self.send_to_parent[0])

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -29,7 +29,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
             data_sources=data_sources
         )
         self.workflow.execution_layers.append(execution_layer)
-        self.workflow.mco.kpis.append(KPISpecification())
+        self.workflow.mco_model.kpis.append(KPISpecification())
 
         self.system_state = SystemState()
         self.workflow_tree = WorkflowTree(
@@ -371,7 +371,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.assertFalse(mco_view.valid)
         self.assertFalse(self.workflow_tree.workflow_view.valid)
 
-        self.workflow.mco.kpis = []
+        self.workflow.mco_model.kpis = []
         self.assertTrue(mco_view.parameter_view.valid)
 
         self.system_state.selected_view = mco_view.parameter_view

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -169,7 +169,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
             _factory_registry=self.factory_registry,
             system_state=self.system_state)
 
-        self.assertIsNone(workflow_tree.workflow_view.model.mco)
+        self.assertIsNone(workflow_tree.workflow_view.model.mco_model)
         self.assertEqual(len(workflow_tree.workflow_view.mco_view), 0)
 
         workflow_tree.mco_selected(workflow_tree.workflow_view)
@@ -179,14 +179,14 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         )
         self.system_state.add_new_entity()
 
-        self.assertIsNotNone(workflow_tree.workflow_view.model.mco)
+        self.assertIsNotNone(workflow_tree.workflow_view.model.mco_model)
         self.assertEqual(len(workflow_tree.workflow_view.mco_view), 1)
-        self.assertIsInstance(workflow_tree.workflow_view.model.mco,
+        self.assertIsInstance(workflow_tree.workflow_view.model.mco_model,
                               BaseMCOModel)
 
     def test_delete_mco(self):
 
-        self.assertIsNotNone(self.workflow_tree.model.mco)
+        self.assertIsNotNone(self.workflow_tree.model.mco_model)
         self.assertEqual(1, len(self.workflow_tree.workflow_view.mco_view))
 
         mco_view = self.workflow_tree.workflow_view.mco_view[0]
@@ -194,7 +194,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.workflow_tree.mco_optimizer_selected(mco_view)
         self.system_state.remove_entity()
 
-        self.assertIsNone(self.workflow_tree.model.mco)
+        self.assertIsNone(self.workflow_tree.model.mco_model)
         self.assertEqual(0, len(self.workflow_tree.workflow_view.mco_view))
 
     def test_new_execution_layer(self):

--- a/force_wfmanager/ui/setup/tests/test_workflow_view.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_view.py
@@ -74,7 +74,7 @@ class TestWorkflowView(WfManagerBaseTestCase, UnittestTools):
 
     def test_set_mco(self):
         mco_model = self.factory_registry.mco_factories[0].create_model()
-        self.workflow_view.set_mco(mco_model)
+        self.workflow_view.model.mco_model = mco_model
 
         self.assertIsNotNone(self.workflow_view.model.mco)
 

--- a/force_wfmanager/ui/setup/tests/test_workflow_view.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_view.py
@@ -76,7 +76,7 @@ class TestWorkflowView(WfManagerBaseTestCase, UnittestTools):
         mco_model = self.factory_registry.mco_factories[0].create_model()
         self.workflow_view.model.mco_model = mco_model
 
-        self.assertIsNotNone(self.workflow_view.model.mco)
+        self.assertIsNotNone(self.workflow_view.model.mco_model)
 
         kpi_view = self.workflow_view.mco_view[0].kpi_view
         parameter_view = self.workflow_view.mco_view[0].parameter_view

--- a/force_wfmanager/ui/setup/tests/wfmanager_base_test_case.py
+++ b/force_wfmanager/ui/setup/tests/wfmanager_base_test_case.py
@@ -79,7 +79,7 @@ class WfManagerBaseTestCase(unittest.TestCase):
         #: Set up workflow containing 1 execution layer with 2
         #: data sources, 2 MCO parameters and 1 listener
         self.workflow = Workflow(
-            mco=self.mco_model,
+            mco_model=self.mco_model,
             execution_layers=[self.execution_layer],
             notification_listeners=[self.notification_listener]
         )

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -420,7 +420,7 @@ class WorkflowTree(ModelView):
 
         # Update the error list with verification checks that occur
         # outside the foce_bdss
-        if self.workflow_view.model.mco is not None:
+        if self.workflow_view.model.mco_model is not None:
             errors += (
                 self.workflow_view.mco_view[0]
                 .parameter_view.verify_model_names()

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -646,7 +646,7 @@ class WorkflowTree(ModelView):
     @triggers_verify
     def new_mco(self, ui_info, object):
         """Adds a new mco to the workflow"""
-        object.set_mco(self.system_state.entity_creator.model)
+        object.model.mco_model = self.system_state.entity_creator.model
         self.system_state.entity_creator.reset_model()
 
     @triggers_verify
@@ -673,7 +673,7 @@ class WorkflowTree(ModelView):
     @triggers_verify
     def delete_mco(self, ui_info, object):
         """Delete a mco from the workflow"""
-        self.workflow_view.set_mco(None)
+        self.workflow_view.model.mco_model = None
 
     @triggers_verify
     def delete_notification_listener(self, ui_info, object):

--- a/force_wfmanager/ui/setup/workflow_view.py
+++ b/force_wfmanager/ui/setup/workflow_view.py
@@ -117,10 +117,6 @@ class WorkflowView(HasTraits):
     #   Public Methods
     # -------------------
 
-    def set_mco(self, mco_model):
-        """Set the MCO"""
-        self.model.mco = mco_model
-
     def remove_execution_layer(self, layer):
         """Removes the execution layer from the model."""
         self.process_view[0].remove_execution_layer(layer)

--- a/force_wfmanager/ui/setup/workflow_view.py
+++ b/force_wfmanager/ui/setup/workflow_view.py
@@ -79,9 +79,9 @@ class WorkflowView(HasTraits):
             variable_names_registry=self.variable_names_registry)]
 
     def _mco_view_default(self):
-        if self.model.mco is not None:
+        if self.model.mco_model is not None:
             return [MCOView(
-                model=self.model.mco,
+                model=self.model.mco_model,
                 variable_names_registry=self.variable_names_registry)]
         else:
             return []
@@ -99,7 +99,7 @@ class WorkflowView(HasTraits):
     def update_process_view(self):
         self.process_view = self._process_view_default()
 
-    @on_trait_change('model:mco')
+    @on_trait_change('model:mco_model')
     def update_mco_view(self):
         self.mco_view = self._mco_view_default()
 

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -20,7 +20,7 @@ def get_basic_variable_names_registry():
     workflow = Workflow()
 
     mco_factory = ProbeMCOFactory(plugin)
-    mco = mco_factory.create_model()
+    mco_model = mco_factory.create_model()
 
     param_factory = ProbeParameterFactory(mco_factory)
     param1 = param_factory.create_model()
@@ -41,8 +41,8 @@ def get_basic_variable_names_registry():
     # third layer
     data_source4 = data_source_factory.create_model()
 
-    workflow.mco = mco
-    mco.parameters = [param1, param2, param3]
+    workflow.mco_model = mco_model
+    mco_model.parameters = [param1, param2, param3]
     workflow.execution_layers.extend([
         ExecutionLayer(
             data_sources=[data_source1, data_source2]
@@ -63,9 +63,9 @@ class VariableNamesRegistryTest(unittest.TestCase):
     def setUp(self):
         self.registry = get_basic_variable_names_registry()
         self.workflow = self.registry.workflow
-        self.param1 = self.workflow.mco.parameters[0]
-        self.param2 = self.workflow.mco.parameters[1]
-        self.param3 = self.workflow.mco.parameters[2]
+        self.param1 = self.workflow.mco_model.parameters[0]
+        self.param2 = self.workflow.mco_model.parameters[1]
+        self.param3 = self.workflow.mco_model.parameters[2]
         self.data_source1 = self.workflow.execution_layers[0].data_sources[0]
         self.data_source2 = self.workflow.execution_layers[0].data_sources[1]
         self.data_source3 = self.workflow.execution_layers[1].data_sources[0]

--- a/force_wfmanager/utils/variable_names_registry.py
+++ b/force_wfmanager/utils/variable_names_registry.py
@@ -69,9 +69,9 @@ class VariableNamesRegistry(HasStrictTraits):
     #: The size of the base list should be the number of layers plus one.
     #: the last one being the variables that are added by the last layer.
     #:
-    #: Listens to: `workflow.mco.parameters.name`,
+    #: Listens to: `workflow.mco_model.parameters.name`,
     #: `workflow.execution_layers.data_sources.output_slot_info.name`,
-    #: `workflow.mco.parameters.type`
+    #: `workflow.mco_model.parameters.type`
     available_input_variables_stack = List(exec_layer_input)
 
     available_output_variables_stack = List(exec_layer_output)
@@ -188,7 +188,7 @@ class VariableNamesRegistry(HasStrictTraits):
         return res
 
     @on_trait_change(
-        'workflow.mco.parameters.[name,type],'
+        'workflow.mco_model.parameters.[name,type],'
         'workflow.execution_layers.data_sources.'
         '[input_slot_info.name,output_slot_info.name]'
     )


### PR DESCRIPTION
This PR approaches the BDSS issue [#246](https://github.com/force-h2020/force-bdss/issues/246) and implements the required API changes.

This PR requires the [BDSS PR](https://github.com/force-h2020/force-bdss/pull/257) to be accepted first.

### Summary

We rename the `Workflow.mco` usage to `Workflow.mco_model` whenever necessary. This is a recent change in BDSS (see [this PR](https://github.com/force-h2020/force-bdss/pull/257))

We remove the redundant `Workflow_view.set_mco` method: now the BDSS changes allow safe attribute assignment directly.

Some general code formatting changes are also present.