### PR TITLE
FIX: Build status reference in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 FORCE Workflow Manager
 ----------------------
 
-.. image:: https://travis-ci.org/force-h2020/force-wfmanager.svg?branch=master
-    :target: https://travis-ci.org/force-h2020/force-wfmanager
+.. image:: https://travis-ci.com/force-h2020/force-wfmanager.svg?branch=master
+    :target: https://travis-ci.com/force-h2020/force-wfmanager
     :alt: Build status
 
 .. image:: http://codecov.io/github/force-h2020/force-wfmanager/coverage.svg?branch=master


### PR DESCRIPTION
The README build status introduced in #337 used travis-ci.org as a host, rather than travis-ci.com.

Force repositories have been migrated to travis-ci.com over a year ago, and so the current status is not referencing the latest commit.