### PR TITLE
FIX: tests fix, removed the weights attribute

### DIFF
--- a/force_wfmanager/server/tests/test_event_deserializer.py
+++ b/force_wfmanager/server/tests/test_event_deserializer.py
@@ -35,8 +35,7 @@ class TestEventDeserializer(unittest.TestCase):
                 "type": "MCOProgressEvent",
                 "model_data": {
                     "optimal_point": [{"value": 1.0}, {"value": 2.0}],
-                    "optimal_kpis": [{"value": 3.0}],
-                    "weights": [1.0],
+                    "optimal_kpis": [{"value": 3.0}]
                 },
             }
         )
@@ -49,8 +48,6 @@ class TestEventDeserializer(unittest.TestCase):
 
         self.assertEqual(len(event.optimal_kpis), 1)
         self.assertEqual(event.optimal_kpis[0].value, 3.0)
-
-        self.assertEqual(event.weights, [1.0])
 
     def test_invalid_cases(self):
         invalid_cases = [

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -259,8 +259,7 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             send_event(
                 MCOProgressEvent(
                     optimal_point=[DataValue(value=1.0)],
-                    optimal_kpis=[DataValue(value=2.0)],
-                    weights=[1.0],
+                    optimal_kpis=[DataValue(value=2.0)]
                 )
             )
 


### PR DESCRIPTION
This PR fixes the failing build of `master` branch.

### Done

Removed the `weights` attribute references from the `MCOProgressEvent` tests.