### PR TITLE
FIX: Open project file

### DIFF
--- a/force_wfmanager/io/project_io.py
+++ b/force_wfmanager/io/project_io.py
@@ -1,7 +1,7 @@
 import logging
 import json
 
-from force_bdss.api import Workflow, WorkflowWriter, WorkflowReader
+from force_bdss.api import WorkflowWriter, WorkflowReader
 
 log = logging.getLogger(__name__)
 
@@ -34,8 +34,9 @@ def write_project_file(workflow_model, analysis_model, file_path):
 
 
 def load_project_file(factory_registry, file_path):
-    """ Load contents of JSON file into:attr:`Workflow` and
-    :attr:`AnalysisModel`.
+    """ Passes the `file_path` to the WorkflowReader and
+    the analysis model loader, to create a Workflow object and
+    an analysis model dictionary.
 
     Parameters
     ----------
@@ -50,16 +51,23 @@ def load_project_file(factory_registry, file_path):
     analysis_model_dict: dict
         Dictionary of analysis model to read, needs to be parsed by
         the analysis model object of the workflow to be loaded in
-    workflow_model:
-        Workflow model
+    workflow_model: Workflow
+        Workflow instance
+    """
+    analysis_model_dict = load_analysis_model(file_path)
+
+    reader = WorkflowReader(factory_registry)
+    workflow_model = reader.read(file_path)
+
+    return analysis_model_dict, workflow_model
+
+
+def load_analysis_model(file_path):
+    """ Opens the `file_path` file and loads the json. Returns the
+    'analysis_model' value from the JSON, or an empty dictionary.
     """
     with open(file_path, "r") as fp:
         project_json = json.load(fp)
 
     analysis_model_dict = project_json.get("analysis_model", {})
-    reader = WorkflowReader(factory_registry)
-    workflow_data = reader.parse_data(project_json)
-
-    workflow_model = Workflow.from_json(factory_registry, workflow_data)
-
-    return analysis_model_dict, workflow_model
+    return analysis_model_dict

--- a/force_wfmanager/io/project_io.py
+++ b/force_wfmanager/io/project_io.py
@@ -21,15 +21,15 @@ def write_project_file(workflow_model, analysis_model, file_path):
         The file_path pointing to the file in which you want to read the
         project file
     """
-    with open(file_path, 'w') as output:
+    with open(file_path, "w") as output:
         # create a dictionary that contains analysis model,
         # workflow and version that can be read back in by
         # :class:`WorkflowReader`, and dump to JSON
         project_json = {}
         writer = WorkflowWriter()
-        project_json['analysis_model'] = analysis_model.as_json()
-        project_json['workflow'] = writer.get_workflow_data(workflow_model)
-        project_json['version'] = writer.version
+        project_json["analysis_model"] = analysis_model.as_json()
+        project_json["workflow"] = writer.get_workflow_data(workflow_model)
+        project_json["version"] = writer.version
         json.dump(project_json, output, indent=4)
 
 
@@ -53,12 +53,10 @@ def load_project_file(factory_registry, file_path):
     workflow_model:
         Workflow model
     """
-
-    with open(file_path, 'r') as fp:
+    with open(file_path, "r") as fp:
         project_json = json.load(fp)
 
-    analysis_model_dict = project_json['analysis_model']
-
+    analysis_model_dict = project_json.get("analysis_model", {})
     reader = WorkflowReader(factory_registry)
     workflow_data = reader.parse_data(project_json)
 

--- a/force_wfmanager/model/analysis_model.py
+++ b/force_wfmanager/model/analysis_model.py
@@ -2,7 +2,14 @@ import json
 import logging
 
 from traits.api import (
-    Bool, Either, HasStrictTraits, Int, List, Property, Tuple, on_trait_change
+    Bool,
+    Either,
+    HasStrictTraits,
+    Int,
+    List,
+    Property,
+    Tuple,
+    on_trait_change,
 )
 
 log = logging.getLogger(__name__)
@@ -48,8 +55,9 @@ class AnalysisModel(HasStrictTraits):
     #: in the allowed range of values.
     #: Listens to :attr:`Plot._plot_index_datasource
     #: <force_wfmanager.central_pane.plot.Plot._plot_index_datasource>`
-    selected_step_indices = Property(Either(None, List(Int)),
-                                     depends_on="_selected_step_indices")
+    selected_step_indices = Property(
+        Either(None, List(Int)), depends_on="_selected_step_indices"
+    )
 
     # ------------------
     #     Listeners
@@ -71,13 +79,13 @@ class AnalysisModel(HasStrictTraits):
         """
         if values is not None:
             for value in values:
-                if (isinstance(value, int) and not
-                        (0 <= value < len(self._evaluation_steps))):
+                if isinstance(value, int) and not (
+                    0 <= value < len(self._evaluation_steps)
+                ):
                     raise ValueError(
                         "Invalid value for selection index {}. Current "
                         "number of steps = {}".format(
-                            value,
-                            len(self._evaluation_steps)
+                            value, len(self._evaluation_steps)
                         )
                     )
 
@@ -102,14 +110,17 @@ class AnalysisModel(HasStrictTraits):
             A pair of values, which can be of any type.
         """
         if len(self.value_names) == 0:
-            raise ValueError("Cannot add evaluation step to an empty "
-                             "Analysis model")
+            raise ValueError(
+                "Cannot add evaluation step to an empty " "Analysis model"
+            )
 
         if len(evaluation_step) != len(self.value_names):
             raise ValueError(
                 "Size of evaluation step '{}' is incompatible "
                 "with the number of value names {}.".format(
-                    evaluation_step, self.value_names))
+                    evaluation_step, self.value_names
+                )
+            )
 
         self._evaluation_steps.append(evaluation_step)
         self._export_enabled = True
@@ -134,11 +145,11 @@ class AnalysisModel(HasStrictTraits):
 
         """
         self._clear_evaluation_steps()
-        self.value_names = tuple(key for key in data.keys())
+        self.value_names = tuple(data.keys())
+        if not self.value_names:
+            return
         for ind, _ in enumerate(data[self.value_names[0]]):
-            step = []
-            for column in self.value_names:
-                step.append(data[column][ind])
+            step = tuple(data[column][ind] for column in self.value_names)
             self.add_evaluation_step(step)
 
     def as_json(self):
@@ -174,10 +185,7 @@ class AnalysisModel(HasStrictTraits):
         if not self._export_enabled:
             return False
 
-        json.dump(self.as_json(),
-                  fp,
-                  sort_keys=False,
-                  indent=4)
+        json.dump(self.as_json(), fp, sort_keys=False, indent=4)
 
         return True
 
@@ -197,10 +205,10 @@ class AnalysisModel(HasStrictTraits):
         if not self._export_enabled:
             return False
 
-        fp.write(', '.join(self.value_names) + '\n')
+        fp.write(", ".join(self.value_names) + "\n")
         for step in self.evaluation_steps:
             # val can have arbitrary type, so cannot
             # e.g. specify a floating point precision
-            fp.write(', '.join([str(val) for val in step]) + '\n')
+            fp.write(", ".join([str(val) for val in step]) + "\n")
 
         return True

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -213,7 +213,11 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
                 old_workflow, self.setup_task.side_pane.workflow_tree.model
             )
 
-            self.setup_task.open_workflow()
+            with mock.patch(
+                "force_wfmanager.wfmanager_setup_task.load_analysis_model"
+            ) as mock_read:
+                mock_read.return_value = {}
+                self.setup_task.open_workflow()
 
             self.assertTrue(mock_reader.called)
 
@@ -221,6 +225,14 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             self.assertNotEqual(
                 old_workflow, self.setup_task.side_pane.workflow_tree.model
             )
+
+            with mock.patch(INFORMATION_PATH) as mock_information:
+                with mock.patch(
+                    "force_wfmanager.wfmanager_setup_task.load_analysis_model"
+                ) as mock_read:
+                    mock_read.return_value = {"some": "data"}
+                    self.setup_task.open_workflow()
+                    mock_information.assert_called()
 
     def test_read_failure(self):
         with mock.patch(FILE_DIALOG_PATH) as mock_file_dialog, mock.patch(
@@ -259,7 +271,7 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             send_event(
                 MCOProgressEvent(
                     optimal_point=[DataValue(value=1.0)],
-                    optimal_kpis=[DataValue(value=2.0)]
+                    optimal_kpis=[DataValue(value=2.0)],
                 )
             )
 

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -306,6 +306,34 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
                 self.review_task.analysis_model.evaluation_steps,
             )
 
+    def test_open_empty_analysis_model(self):
+        mock_open = mock.mock_open()
+        with mock.patch(
+            RESULTS_FILE_DIALOG_PATH
+        ) as mock_file_dialog, mock.patch(
+            RESULTS_JSON_LOAD_PATH
+        ) as mock_json, mock.patch(
+            RESULTS_FILE_OPEN_PATH, mock_open, create=True
+        ):
+            mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
+            mock_json.return_value = {"version": "1", "workflow": {}}
+            old_workflow = self.review_task.workflow_model
+            self.review_task.open_project()
+
+            self.assertTrue(mock_open.called)
+            self.assertTrue(mock_json.called)
+
+            self.assertIsNot(old_workflow, self.review_task.workflow_model)
+            self.assertIsNot(
+                self.setup_task.workflow_model, self.review_task.workflow_model
+            )
+            self.assertEqual(
+                tuple(), self.review_task.analysis_model.value_names
+            )
+            self.assertEqual(
+                [], self.review_task.analysis_model.evaluation_steps
+            )
+
     def test_open_project_failure(self):
         mock_open = mock.mock_open()
         mock_open.side_effect = IOError("OUPS")

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -352,46 +352,6 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             )
 
         mock_open = mock.mock_open()
-        with mock.patch(
-            RESULTS_FILE_DIALOG_PATH
-        ) as mock_file_dialog, mock.patch(
-            RESULTS_JSON_LOAD_PATH
-        ) as mock_json, mock.patch(
-            RESULTS_ERROR_PATH
-        ) as mock_error, mock.patch(
-            RESULTS_FILE_OPEN_PATH, mock_open, create=True
-        ), mock.patch(
-            RESULTS_READER_PATH
-        ) as mock_reader:
-            mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
-            mock_reader.side_effect = mock_file_reader
-            mock_json.return_value = {
-                "asdfsadf": {"x": [1], "y": [2]},
-                "123456": "1",
-                "blah": {},
-            }
-
-            success = self.review_task.open_project()
-            old_workflow = self.review_task.workflow_model
-            old_analysis = self.review_task.analysis_model
-            self.assertTrue(mock_open.called)
-            self.assertTrue(mock_json.called)
-            self.assertFalse(success)
-            # it should not get to the stage where the wfreader is called
-            self.assertFalse(mock_reader.called)
-            mock_error.assert_called_with(
-                None,
-                "Unable to find analysis model:\n\n{}".format(
-                    "'analysis_model'"
-                ),
-                "Error when loading project",
-            )
-            self.assertEqual(old_workflow, self.setup_task.workflow_model)
-            self.assertEqual(old_analysis, self.setup_task.analysis_model)
-            self.assertEqual(old_workflow, self.review_task.workflow_model)
-            self.assertEqual(old_analysis, self.review_task.analysis_model)
-
-        mock_open = mock.mock_open()
         error = ValueError("some wrong value")
         mock_open.side_effect = error
         with mock.patch(

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -20,7 +20,6 @@ from force_wfmanager.ui.review.results_pane import ResultsPane
 from force_wfmanager.model.analysis_model import AnalysisModel
 
 from .mock_methods import (
-    mock_file_reader,
     mock_file_writer,
     mock_dialog,
     mock_return_args,
@@ -41,7 +40,7 @@ RESULTS_WRITER_PATH = (
 RESULTS_READER_PATH = "force_wfmanager.io.project_io.WorkflowReader"
 RESULTS_ERROR_PATH = "force_wfmanager.wfmanager_review_task.error"
 ANALYSIS_WRITE_PATH = (
-    "force_wfmanager.io.analysis_model_io." "write_analysis_model"
+    "force_wfmanager.io.analysis_model_io.write_analysis_model"
 )
 ANALYSIS_FILE_OPEN_PATH = "force_wfmanager.io.analysis_model_io.open"
 
@@ -92,6 +91,10 @@ def get_probe_wfmanager_tasks(wf_manager=None, contributed_uis=None):
         task.create_dock_panes()
 
     return tasks[0], tasks[1]
+
+
+def return_workflow(file_path):
+    return Workflow()
 
 
 class TestWFManagerTasks(GuiTestAssistant, TestCase):
@@ -269,7 +272,11 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             old_analysis = copy.deepcopy(self.review_task.analysis_model)
             self.assertEqual(old_workflow, self.setup_task.workflow_model)
 
-            self.review_task.open_project()
+            with mock.patch(
+                    "force_bdss.io.workflow_reader.WorkflowReader.read"
+            ) as mock_read:
+                mock_read.side_effect = return_workflow
+                self.review_task.open_project()
 
             self.assertTrue(mock_open.called)
             self.assertTrue(mock_json.called)
@@ -318,7 +325,11 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
             mock_json.return_value = {"version": "1", "workflow": {}}
             old_workflow = self.review_task.workflow_model
-            self.review_task.open_project()
+            with mock.patch(
+                "force_bdss.io.workflow_reader.WorkflowReader.read"
+            ) as mock_read:
+                mock_read.side_effect = return_workflow
+                self.review_task.open_project()
 
             self.assertTrue(mock_open.called)
             self.assertTrue(mock_json.called)

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -353,7 +353,6 @@ class WfManagerReviewTask(Task):
             )
             log.exception("Error loading project file")
             return False
-
         except Exception as e:
             error(
                 None,

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -345,16 +345,6 @@ class WfManagerReviewTask(Task):
             # share the analysis model with the setup_task
             self.analysis_model.from_dict(analysis_model_dict)
             self.setup_task.analysis_model = self.analysis_model
-
-        except KeyError as e:
-            error(
-                None,
-                "Unable to find analysis model:\n\n{}".format(str(e)),
-                "Error when loading project",
-            )
-            log.exception("KeyError when loading project")
-            return False
-
         except IOError as e:
             error(
                 None,

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -1,5 +1,4 @@
 import logging
-import copy
 
 from pyface.api import ImageResource, FileDialog, OK, error
 from pyface.tasks.action.api import SMenuBar, SMenu, TaskAction, SToolBar
@@ -338,7 +337,10 @@ class WfManagerReviewTask(Task):
 
             # create two separate workflows, so that setup task can be
             # edited without changing the review task copy
-            self.setup_task.workflow_model = copy.copy(self.workflow_model)
+            new_workflow = Workflow.from_json(
+                self.factory_registry, self.workflow_model.__getstate__()
+            )
+            self.setup_task.workflow_model = new_workflow
 
             # share the analysis model with the setup_task
             self.analysis_model.from_dict(analysis_model_dict)

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -46,6 +46,7 @@ from force_wfmanager.ui.setup.side_pane import SidePane
 from force_wfmanager.ui.setup.system_state import SystemState
 
 from force_wfmanager.wfmanager import TaskToggleGroupAccelerator
+from force_wfmanager.io.project_io import load_analysis_model
 
 
 log = logging.getLogger(__name__)
@@ -320,51 +321,6 @@ class WfManagerSetupTask(Task):
     #   Private Methods
     # ------------------
 
-    def _write_workflow(self, file_path):
-        """ Creates a JSON file in the file_path and write the workflow
-        description in it
-        Parameters
-        ----------
-        file_path: str
-            The file_path pointing to the file in which you want to write the
-            workflow
-        Returns
-        -------
-        Boolean:
-            True if it was a success to write in the file, False otherwise
-        """
-        for hook_manager in self.ui_hooks_managers:
-            try:
-                hook_manager.before_save(self)
-            except Exception:
-                log.exception(
-                    "Failed before_save hook "
-                    "for hook manager {}".format(
-                        hook_manager.__class__.__name__
-                    )
-                )
-
-        try:
-            write_workflow_file(self.workflow_model, file_path)
-        except IOError as e:
-            error(
-                None,
-                "Cannot save in the requested file:\n\n{}".format(str(e)),
-                "Error when saving workflow",
-            )
-            log.exception("Error when saving workflow")
-            return False
-        except Exception as e:
-            error(
-                None,
-                "Cannot save the workflow:\n\n{}".format(str(e)),
-                "Error when saving workflow",
-            )
-            log.exception("Error when saving workflow")
-            return False
-        else:
-            return True
-
     def _execute_bdss(self, workflow_path):
         """Secondary thread executor routine.
         This executes the BDSS and wait for its completion.
@@ -540,7 +496,62 @@ class WfManagerSetupTask(Task):
                 "Error when reading file",
             )
         else:
-            self.current_file = file_path
+            analysis_model = load_analysis_model(file_path)
+            if not analysis_model:
+                self.current_file = file_path
+            else:
+                information(
+                    None,
+                    "Project file was loaded instead of the "
+                    "Workflow file. Analysis data was discarded "
+                    "and will not be displayed.\nYou can load a "
+                    "Project file using 'Open Project'.",
+                )
+
+    def _write_workflow(self, file_path):
+        """ Creates a JSON file in the file_path and write the workflow
+        description in it
+        Parameters
+        ----------
+        file_path: str
+            The file_path pointing to the file in which you want to write the
+            workflow
+        Returns
+        -------
+        Boolean:
+            True if it was a success to write in the file, False otherwise
+        """
+        for hook_manager in self.ui_hooks_managers:
+            try:
+                hook_manager.before_save(self)
+            except Exception:
+                log.exception(
+                    "Failed before_save hook "
+                    "for hook manager {}".format(
+                        hook_manager.__class__.__name__
+                    )
+                )
+
+        try:
+            write_workflow_file(self.workflow_model, file_path)
+        except IOError as e:
+            error(
+                None,
+                "Cannot save in the requested file:\n\n{}".format(str(e)),
+                "Error when saving workflow",
+            )
+            log.exception("Error when saving workflow")
+            return False
+        except Exception as e:
+            error(
+                None,
+                "Cannot save the workflow:\n\n{}".format(str(e)),
+                "Error when saving workflow",
+            )
+            log.exception("Error when saving workflow")
+            return False
+        else:
+            return True
 
     def save_workflow(self):
         """ Saves the workflow into the currently used file. If there is no

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -502,10 +502,11 @@ class WfManagerSetupTask(Task):
             else:
                 information(
                     None,
-                    "Project file was loaded instead of the "
-                    "Workflow file. Analysis data was discarded "
-                    "and will not be displayed.\nYou can load a "
-                    "Project file using 'Open Project'.",
+                    "Project file found instead of Workflow "
+                    "file during start up.",
+                    informative="Analysis data will not be "
+                    "loaded into WfManager upon launch. You can load a "
+                    "Project file using 'Open Project' in the Review Task."
                 )
 
     def _write_workflow(self, file_path):


### PR DESCRIPTION
This PR approaches #303 

### Summary

The `force_wfmanager` can executed with a Workflow or Project File. When a Project File is loaded, the user should not be able to `"Save"` the workflow file from the setup pane, as it would overwrite the Project file and therefore the analysis model data will be erased. Since the Workflow and Project files have the same file format (and share the .json extension), it is not possible to guess the file content without reading the file.

In the `setup_pane` environment, we check whether the loaded file contains the `analysis_model` data, and if it does, the `"Save"` button activates the `"Save as"` function.

In the `review_pane` environment, if the user loads a Workflow file instead of a Project file, the WorkflowManager can now process the workflow file and assigns an empty analysis model to the review task.

### Done
- Refactored the `project_io.py` module. The `analysis_model` is now loaded by a new `load_analysis_model` function.
- Workflow file can be loaded to the review pane without the WorkflowManager throwing an error.
- Minor refactoring and bugs fixes in review_task and setup_task.