### PR TITLE
MAINT: Updated dependencies for version 0.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,8 +75,8 @@ Documentation
 Maintenance and code organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Updated traitsui to version 6.1.3-2 (#275, #288, #341)
-* Updated pyface to version 6.1.2-1 (#275, #288, #341)
+* Updated traitsui to version 6.1.3-5 (#275, #288, #341, #356)
+* Updated pyface to version 6.1.2-5 (#275, #288, #341, #356)
 * Updated chaco to version 4.8.0-1 (#341)
 * Updated qt to version 4.8.7-19 (#288)
 * Updated pyzmq to version 16.0.0-7 (#288)

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -7,12 +7,12 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
-    "pyface==6.1.2-1",
+    "pyface==6.1.2-5",
     "pygments==2.2.0-1",
     "pyqt==4.11.4-7",
     "qt==4.8.7-10",
     "sip==4.17-4",
-    "traitsui==6.1.3-2",
+    "traitsui==6.1.3-5",
     "numpy==1.15.4-2",
     "chaco==4.8.0-1",
     "pyzmq==16.0.0-7",


### PR DESCRIPTION
 This PR bumps Pyface and TraitsUI to latest versions available on EDM, in order to support https://github.com/force-h2020/force-bdss/pull/289

- `pyface` 6.1.2-1 --> 6.1.2-5
- `traitsui` 6.1.3-2 --> 6.1.3-5