### PR TITLE
DEV: Delivering UIEventMixin events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b dev/data-source-event
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git -b dev/data-source-event
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/force_wfmanager/notifications/tests/test_ui_notification.py
+++ b/force_wfmanager/notifications/tests/test_ui_notification.py
@@ -3,6 +3,7 @@ from testfixtures import LogCapture
 from threading import Event
 
 from force_bdss.api import (
+    BaseDriverEvent,
     MCOStartEvent,
     MCOProgressEvent,
     MCOFinishEvent,
@@ -104,6 +105,12 @@ class TestUINotification(unittest.TestCase):
             TypeError, "Event is not a BaseDriverEvent"
         ):
             listener.deliver("not an event")
+
+        with mock.patch.object(
+            listener._pub_socket, "send_multipart"
+        ) as mock_send:
+            listener.deliver(BaseDriverEvent())
+        mock_send.assert_not_called()
 
     def test_finalize(self):
         self.listener.initialize(self.model)

--- a/force_wfmanager/notifications/ui_notification.py
+++ b/force_wfmanager/notifications/ui_notification.py
@@ -9,6 +9,8 @@ from force_bdss.api import (
     BaseDriverEvent,
     UIEventNotificationMixin,
 )
+from force_bdss.api import UIEventMixin
+
 
 log = logging.getLogger(__name__)
 
@@ -182,11 +184,15 @@ class UINotification(BaseNotificationListener, UIEventNotificationMixin):
         if not isinstance(event, BaseDriverEvent):
             raise TypeError("Event is not a BaseDriverEvent")
 
-        data = event.dumps_json()
+        if isinstance(event, UIEventMixin):
+            data = event.dumps_json()
 
-        self._pub_socket.send_multipart(
-            [x.encode("utf-8") for x in ["MESSAGE", self._identifier, data]]
-        )
+            self._pub_socket.send_multipart(
+                [
+                    x.encode("utf-8")
+                    for x in ["MESSAGE", self._identifier, data]
+                ]
+            )
 
     def finalize(self):
         """ Disconnects from the ZMQServer."""


### PR DESCRIPTION
This PR closes #361 

### Summary

We introduced a small `UIEventMixin` class in [#290](https://github.com/force-h2020/force-bdss/pull/290) that indicates that this particular event type should be parsed and sent to the WorkflowManager.

Here we add the actual logic to filter this event type before delivering via the `UINotification.deliver`

### Done

- Added a `if isinstance(event, UIEventMixin)` check in the `UIEventMixin.deliver` method. Only events that are subclasses of the `UIEventMixin` will be dumped and sent to the ZMQ server.