### PR TITLE
ENH: Verification on any BaseMCOParameter or KPISpecification trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git -b dev/vector-mco-parameter
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b dev/vector-mco-parameter
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/force_wfmanager/tests/probe_classes.py
+++ b/force_wfmanager/tests/probe_classes.py
@@ -6,6 +6,9 @@ from traits.trait_types import Int
 from force_bdss.tests.probe_classes.data_source import (
     ProbeDataSourceModel, ProbeDataSourceFactory
 )
+from force_bdss.tests.probe_classes.mco import (
+    ProbeParameter, ProbeParameterFactory, ProbeMCOFactory
+)
 from force_bdss.tests.probe_classes.factory_registry import (
     ProbeFactoryRegistry
 )
@@ -57,3 +60,20 @@ class ProbeDataSourceFactory2(ProbeDataSourceFactory):
 
     def get_model_class(self):
         return ProbeDataSourceModel2
+
+
+class ProbeParameter2(ProbeParameter):
+
+    test_trait = Int(13, desc='Test trait', verify=True)
+
+
+class ProbeParameterFactory2(ProbeParameterFactory):
+
+    def get_model_class(self):
+        return ProbeParameter2
+
+
+class ProbeMCOFactory2(ProbeMCOFactory):
+
+    def get_parameter_factory_classes(self):
+        return [ProbeParameterFactory2]

--- a/force_wfmanager/tests/probe_classes.py
+++ b/force_wfmanager/tests/probe_classes.py
@@ -49,31 +49,3 @@ class ProbeWfManager(WfManager):
 
         # 'Run' the application by creating windows without an event loop
         self.run = self._create_windows
-
-
-class ProbeDataSourceModel2(ProbeDataSourceModel):
-
-    test_trait = Int(13, desc='Test trait', verify=True)
-
-
-class ProbeDataSourceFactory2(ProbeDataSourceFactory):
-
-    def get_model_class(self):
-        return ProbeDataSourceModel2
-
-
-class ProbeParameter2(ProbeParameter):
-
-    test_trait = Int(13, desc='Test trait', verify=True)
-
-
-class ProbeParameterFactory2(ProbeParameterFactory):
-
-    def get_model_class(self):
-        return ProbeParameter2
-
-
-class ProbeMCOFactory2(ProbeMCOFactory):
-
-    def get_parameter_factory_classes(self):
-        return [ProbeParameterFactory2]

--- a/force_wfmanager/tests/probe_classes.py
+++ b/force_wfmanager/tests/probe_classes.py
@@ -1,14 +1,6 @@
 from envisage.core_plugin import CorePlugin
 from envisage.ui.tasks.tasks_plugin import TasksPlugin
 
-from traits.trait_types import Int
-
-from force_bdss.tests.probe_classes.data_source import (
-    ProbeDataSourceModel, ProbeDataSourceFactory
-)
-from force_bdss.tests.probe_classes.mco import (
-    ProbeParameter, ProbeParameterFactory, ProbeMCOFactory
-)
 from force_bdss.tests.probe_classes.factory_registry import (
     ProbeFactoryRegistry
 )

--- a/force_wfmanager/ui/setup/mco/base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/base_mco_options_model_view.py
@@ -72,8 +72,7 @@ class BaseMCOOptionsModelView(ModelView):
 
         return _combobox_values
 
-    # Assign an on_trait_change decorator to specify traits to listen to
-    # in child class implementation
+    @on_trait_change('model.+verify')
     def model_change(self):
         """Raise verify workflow event upon change in model"""
         self.verify_workflow_event = True

--- a/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
@@ -65,5 +65,3 @@ class MCOParameterModelView(BaseMCOOptionsModelView):
                 self.model.type = self.available_variables[index][1]
             except ValueError:
                 self.model.type = ''
-
-        self.model_change()

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
@@ -8,7 +8,6 @@ from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
 from force_wfmanager.ui.setup.mco.base_mco_options_model_view import (
     BaseMCOOptionsModelView
 )
-from force_wfmanager.tests.probe_classes import ProbeMCOFactory2
 
 
 class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
@@ -50,7 +49,7 @@ class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
         factory = ProbeMCOFactory({'id': '0', 'name': 'plugin'})
         parameter_factory = factory.parameter_factories[0]
         model = parameter_factory.create_model()
-        self.mco_options_model_view.model=model
+        self.mco_options_model_view.model = model
 
         with self.assertTraitChanges(
                 self.mco_options_model_view, 'verify_workflow_event', 1):

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
@@ -7,12 +7,12 @@ from force_bdss.api import KPISpecification
 from force_wfmanager.ui.setup.mco.base_mco_options_model_view import (
     BaseMCOOptionsModelView
 )
+from force_wfmanager.tests.probe_classes import ProbeMCOFactory2
 
 
 class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
 
     def setUp(self):
-
         self.mco_options_model_view = BaseMCOOptionsModelView()
 
     def test_mco_options_model_view_init(self):
@@ -43,3 +43,14 @@ class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
             'KPI is not named',
             error_message[0].local_error
         )
+
+    def test_verify_mco_options(self):
+
+        factory = ProbeMCOFactory2({'id': '0', 'name': 'plugin'})
+        parameter_factory = factory.parameter_factories[0]
+        model = parameter_factory.create_model()
+        self.mco_options_model_view.model=model
+
+        with self.assertTraitChanges(
+                self.mco_options_model_view, 'verify_workflow_event', 1):
+            model.test_trait = 10

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
@@ -3,6 +3,7 @@ import unittest
 from traits.testing.unittest_tools import UnittestTools
 
 from force_bdss.api import KPISpecification
+from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
 
 from force_wfmanager.ui.setup.mco.base_mco_options_model_view import (
     BaseMCOOptionsModelView
@@ -46,7 +47,7 @@ class TestBaseMCOOptionsModelView(unittest.TestCase, UnittestTools):
 
     def test_verify_mco_options(self):
 
-        factory = ProbeMCOFactory2({'id': '0', 'name': 'plugin'})
+        factory = ProbeMCOFactory({'id': '0', 'name': 'plugin'})
         parameter_factory = factory.parameter_factories[0]
         model = parameter_factory.create_model()
         self.mco_options_model_view.model=model

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -1,10 +1,11 @@
 from traits.testing.unittest_tools import UnittestTools
 
-from force_bdss.api import (OutputSlotInfo, InputSlotInfo, BaseDataSourceModel)
+from force_bdss.api import OutputSlotInfo, InputSlotInfo, BaseDataSourceModel
+from force_bdss.tests.probe_classes.data_source import ProbeDataSourceFactory
 
-from force_wfmanager.tests.probe_classes import ProbeDataSourceFactory2
-from force_wfmanager.ui.setup.process.data_source_view import \
+from force_wfmanager.ui.setup.process.data_source_view import (
     DataSourceView
+)
 from force_wfmanager.ui.setup.tests.wfmanager_base_test_case import (
     WfManagerBaseTestCase
 )
@@ -111,7 +112,7 @@ class TestDataSourceView(WfManagerBaseTestCase, UnittestTools):
 
     def test_verify_data_source(self):
 
-        factory = ProbeDataSourceFactory2({'id': '0', 'name': 'plugin'})
+        factory = ProbeDataSourceFactory({'id': '0', 'name': 'plugin'})
         model = factory.create_model()
         data_source_view = DataSourceView(
             model=model,

--- a/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
+++ b/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
@@ -12,9 +12,6 @@ from force_bdss.tests.probe_classes.probe_extension_plugin import (
 from force_wfmanager.tests.dummy_classes.dummy_model_info import (
     DummyModelInfo
 )
-from force_wfmanager.tests.probe_classes import (
-    ProbeDataSourceModel2 as ProbeDataSourceModelDescription
-)
 from force_wfmanager.ui.setup.new_entity_creator import (
      NewEntityCreator
 )
@@ -106,7 +103,7 @@ class TestNewEntityModel(unittest.TestCase):
     def test_description_editable_data_source(self):
         model, _ = self._get_data_selector()
         model.selected_factory = model.factories[0]
-        model.model = ProbeDataSourceModelDescription(
+        model.model = ProbeDataSourceModel(
             model.selected_factory)
 
         self.assertIn("Test trait",

--- a/force_wfmanager/ui/tests/test_ui_utils.py
+++ b/force_wfmanager/ui/tests/test_ui_utils.py
@@ -48,7 +48,7 @@ class TestUiUtils(unittest.TestCase):
     def test_model_info(self):
 
         self.assertEqual(model_info(None), [])
-        self.assertEqual(len(model_info(self.model)), 4)
+        self.assertEqual(len(model_info(self.model)), 5)
 
     def test_class_description(self):
 


### PR DESCRIPTION
This PR effectively carries the same verification functionalities in #296 to `BaseMCOParamter` and `KPISpecification` subclasses.

It also removes some probe classes that have been ported over to `force_bdss` in https://github.com/force-h2020/force-bdss/pull/295, and so requires these updates in order for the unit tests to pass.