### PR TITLE
ENH: Control enabling of SetupPane UI features during BDSS run

### DIFF
--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -331,6 +331,7 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             hook_manager = self.setup_task.ui_hooks_managers[0]
 
             self.assertTrue(self.setup_task.side_pane.ui_enabled)
+            self.assertTrue(self.setup_task.setup_pane.ui_enabled)
             self.assertFalse(hook_manager.before_execution_called)
             self.assertFalse(hook_manager.after_execution_called)
 
@@ -341,6 +342,11 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
 
             with self.event_loop_until_condition(
                 lambda: self.setup_task.side_pane.ui_enabled
+            ):
+                pass
+
+            with self.event_loop_until_condition(
+                lambda: self.setup_task.setup_pane.ui_enabled
             ):
                 pass
 
@@ -422,6 +428,7 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
                 mock_chk_call.side_effect = exception
 
                 self.assertTrue(self.setup_task.side_pane.ui_enabled)
+                self.assertTrue(self.setup_task.setup_pane.ui_enabled)
 
                 with self.event_loop_until_condition(
                     lambda: mock_chk_call.called
@@ -429,6 +436,10 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
                     self.setup_task.run_bdss()
 
                 ui_enabled = self.setup_task.side_pane.ui_enabled
+                with self.event_loop_until_condition(lambda: ui_enabled):
+                    pass
+
+                ui_enabled = self.setup_task.setup_pane.ui_enabled
                 with self.event_loop_until_condition(lambda: ui_enabled):
                     pass
 
@@ -480,10 +491,12 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             mock_error.side_effect = mock_return_args
 
             self.assertTrue(self.setup_task.side_pane.ui_enabled)
+            self.assertTrue(self.setup_task.setup_pane.ui_enabled)
 
             self.setup_task.run_bdss()
 
             self.assertTrue(self.setup_task.side_pane.ui_enabled)
+            self.assertTrue(self.setup_task.setup_pane.ui_enabled)
 
             self.assertEqual(
                 mock_error.call_args[0][1], "Unable to run BDSS: write failed"

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -217,7 +217,7 @@ class SetupPane(TraitsTaskPane):
                             show_border=True,
                         ),
                     ),
-                enabled_when="ui_enabled"
+                    enabled_when="ui_enabled"
                 ),
             ),
             width=500,

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -33,6 +33,9 @@ class SetupPane(TraitsTaskPane):
     #: Name displayed as the title of this pane
     name = 'Setup Pane'
 
+    #: Enables or disables the object views displayed
+    ui_enabled = Bool(True)
+
     # ------------------
     # Derived Attributes
     # ------------------
@@ -145,7 +148,8 @@ class SetupPane(TraitsTaskPane):
                         editor=InstanceEditor(),
                         style="custom",
                         ),
-                    visible_when="main_view_visible"
+                    visible_when="main_view_visible",
+                    enabled_when="ui_enabled"
                 ),
                 # MCO Parameter and KPI views
                 VGroup(
@@ -154,8 +158,8 @@ class SetupPane(TraitsTaskPane):
                         editor=InstanceEditor(),
                         style="custom",
                     ),
-                    visible_when="mco_view_visible"
-
+                    visible_when="mco_view_visible",
+                    enabled_when="ui_enabled"
                 ),
                 # Process Tree Views
                 HGroup(
@@ -213,6 +217,7 @@ class SetupPane(TraitsTaskPane):
                             show_border=True,
                         ),
                     ),
+                enabled_when="ui_enabled"
                 ),
             ),
             width=500,

--- a/force_wfmanager/ui/setup/side_pane.py
+++ b/force_wfmanager/ui/setup/side_pane.py
@@ -1,5 +1,5 @@
 from pyface.tasks.api import TraitsDockPane
-from traits.api import Bool, Button, Instance, on_trait_change
+from traits.api import Bool, Button, Instance, on_trait_change, Property
 from traitsui.api import UItem, VGroup, View
 
 from force_bdss.api import IFactoryRegistry, Workflow
@@ -78,7 +78,7 @@ class SidePane(TraitsDockPane):
 
     traits_view = View(
         VGroup(
-            UItem('workflow_tree', style='custom', enabled_when="ui_enabled"),
+            UItem('workflow_tree', style='custom'),
             UItem('run_button', enabled_when="run_enabled")
         )
     )

--- a/force_wfmanager/ui/setup/side_pane.py
+++ b/force_wfmanager/ui/setup/side_pane.py
@@ -66,7 +66,7 @@ class SidePane(TraitsDockPane):
     #: Run button for running the computation
     run_button = Button('Run')
 
-    #: Enables or disables the workflow tree.
+    #: Enables or disables features of the side pane during runtime.
     ui_enabled = Bool(True)
 
     #: Enable or disable the run button.
@@ -102,9 +102,10 @@ class SidePane(TraitsDockPane):
 
     @on_trait_change('workflow_tree.workflow_view.valid')
     def update_run_btn_status(self):
-        """Enables/Disables the run button if the workflow is valid/invalid"""
+        """Enables/Disables the run button if the workflow is valid/invalid
+        or if a computation is running"""
         self.run_enabled = (
-                self.workflow_tree.workflow_view.valid and self.ui_enabled
+            self.workflow_tree.workflow_view.valid and self.ui_enabled
         )
 
     @on_trait_change('workflow_model', post_init=True)

--- a/force_wfmanager/ui/setup/side_pane.py
+++ b/force_wfmanager/ui/setup/side_pane.py
@@ -1,5 +1,5 @@
 from pyface.tasks.api import TraitsDockPane
-from traits.api import Bool, Button, Instance, on_trait_change, Property
+from traits.api import Bool, Button, Instance, on_trait_change
 from traitsui.api import UItem, VGroup, View
 
 from force_bdss.api import IFactoryRegistry, Workflow

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -78,6 +78,7 @@ class TestSetupPane(GuiTestAssistant, TestCase):
         self.assertEqual(self.setup_pane.system_state,
                          self.system_state)
         self.assertTrue(self.setup_pane.main_view_visible)
+        self.assertTrue(self.setup_pane.ui_enabled)
 
     def test_mco_view(self):
 

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -77,6 +77,9 @@ class WfManagerSetupTask(Task):
     #: Current workflow file on which the application is writing
     current_file = File()
 
+    #: Setup Pane containing the object views to edit
+    setup_pane = Instance(SetupPane)
+
     #: Side Pane containing the tree editor for the Workflow and the Run button
     side_pane = Instance(SidePane)
 
@@ -259,6 +262,9 @@ class WfManagerSetupTask(Task):
     def _workflow_model_default(self):
         return Workflow()
 
+    def _setup_pane_default(self):
+        return SetupPane(system_state=self.system_state)
+
     def _side_pane_default(self):
         return SidePane(
             workflow_model=self.workflow_model,
@@ -316,10 +322,11 @@ class WfManagerSetupTask(Task):
 
     @on_trait_change("computation_running")
     def update_pane_active_status(self):
-        """Disables the saving/loading toolbar buttons and the TreePane UI
+        """Disables the saving/loading toolbar buttons and the SetupPane UI
         if a computation is running, and re-enables them when it finishes."""
 
         self.side_pane.ui_enabled = not self.computation_running
+        self.setup_pane.ui_enabled = not self.computation_running
         self.save_load_enabled = not self.computation_running
         self.run_enabled = not self.computation_running
 
@@ -479,7 +486,7 @@ class WfManagerSetupTask(Task):
         """ Creates the central pane which contains the layer info part
         (factory selection and new object configuration editors)
         """
-        return SetupPane(system_state=self.system_state)
+        return self.setup_pane
 
     def create_dock_panes(self):
         """ Creates the dock panes """


### PR DESCRIPTION
This PR closes #358 

It adds a new attribute `ui_enabled` to the `SetupPane` class, which controls whether the UI features are enabled or not during a BDSS run. By doing so we are also able to remove the same control on the `SidePane` tree view, so that it remains selectable during run time and allows the user to look at the `Workflow` state without being able to edit anything.

The `SidePane.ui_enabled` attribute is retained, as it is involved in the logic defining the status of the run buttons.

### Future Work
- The view objects of the `SetupPane` are a bit convoluted, and we are not able to simply set the enable status of a single object. It would be great if we could refactor the view into something that has a single `Group`, so that `visible` or `enabled` states could be easily set for the entire pane. 