### PR TITLE
switch if length of data set rather than data

### DIFF
--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -359,7 +359,7 @@ class BasePlot(BaseDataView):
     def calculate_axis_bounds(data):
         if len(data) < 1:
             bounds = (-1, 1)
-        if (len(data) > 1) and (data[0] != data[1]):
+        elif (len(data) > 1) and (data[0] != data[1]):
                 axis_max = max(data) * 1.0
                 axis_min = min(data)
                 axis_spread = abs(axis_max - axis_min)
@@ -368,7 +368,6 @@ class BasePlot(BaseDataView):
                 bounds = (axis_min, axis_max)
         else:
             bounds = (data[0] - 0.5, data[0] + 0.5)
-
         return bounds
 
     def _reset_zoomtool(self):

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -357,17 +357,18 @@ class BasePlot(BaseDataView):
 
     @staticmethod
     def calculate_axis_bounds(data):
-        if len(data) < 1:
-            bounds = (-1, 1)
-        elif (len(data) > 1) and (data[0] != data[1]):
+        set_length = len(set(data))
+        if set_length > 1:
             axis_max = max(data) * 1.0
             axis_min = min(data)
             axis_spread = abs(axis_max - axis_min)
             axis_max = axis_max + 0.1 * axis_spread
             axis_min = axis_min - 0.1 * axis_spread
             bounds = (axis_min, axis_max)
-        else:
+        elif set_length == 1:
             bounds = (data[0] - 0.5, data[0] + 0.5)
+        else:
+            bounds = (-1, 1)
         return bounds
 
     def _reset_zoomtool(self):

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -360,12 +360,12 @@ class BasePlot(BaseDataView):
         if len(data) < 1:
             bounds = (-1, 1)
         elif (len(data) > 1) and (data[0] != data[1]):
-                axis_max = max(data) * 1.0
-                axis_min = min(data)
-                axis_spread = abs(axis_max - axis_min)
-                axis_max = axis_max + 0.1 * axis_spread
-                axis_min = axis_min - 0.1 * axis_spread
-                bounds = (axis_min, axis_max)
+            axis_max = max(data) * 1.0
+            axis_min = min(data)
+            axis_spread = abs(axis_max - axis_min)
+            axis_max = axis_max + 0.1 * axis_spread
+            axis_min = axis_min - 0.1 * axis_spread
+            bounds = (axis_min, axis_max)
         else:
             bounds = (data[0] - 0.5, data[0] + 0.5)
         return bounds

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -357,14 +357,15 @@ class BasePlot(BaseDataView):
 
     @staticmethod
     def calculate_axis_bounds(data):
-        if len(data) > 1:
+        set_size = len(set(data))
+        if set_size > 1:
             axis_max = max(data) * 1.0
             axis_min = min(data)
             axis_spread = abs(axis_max - axis_min)
             axis_max = axis_max + 0.1 * axis_spread
             axis_min = axis_min - 0.1 * axis_spread
             bounds = (axis_min, axis_max)
-        elif len(data) == 1:
+        elif set_size == 1:
             bounds = (data[0] - 0.5, data[0] + 0.5)
         else:
             bounds = (-1, 1)

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -357,18 +357,18 @@ class BasePlot(BaseDataView):
 
     @staticmethod
     def calculate_axis_bounds(data):
-        set_size = len(set(data))
-        if set_size > 1:
-            axis_max = max(data) * 1.0
-            axis_min = min(data)
-            axis_spread = abs(axis_max - axis_min)
-            axis_max = axis_max + 0.1 * axis_spread
-            axis_min = axis_min - 0.1 * axis_spread
-            bounds = (axis_min, axis_max)
-        elif set_size == 1:
-            bounds = (data[0] - 0.5, data[0] + 0.5)
-        else:
+        if len(data) < 1:
             bounds = (-1, 1)
+        if (len(data) > 1) and (data[0] != data[1]):
+                axis_max = max(data) * 1.0
+                axis_min = min(data)
+                axis_spread = abs(axis_max - axis_min)
+                axis_max = axis_max + 0.1 * axis_spread
+                axis_min = axis_min - 0.1 * axis_spread
+                bounds = (axis_min, axis_max)
+        else:
+            bounds = (data[0] - 0.5, data[0] + 0.5)
+
         return bounds
 
     def _reset_zoomtool(self):

--- a/force_wfmanager/ui/review/tests/test_plot.py
+++ b/force_wfmanager/ui/review/tests/test_plot.py
@@ -230,7 +230,7 @@ class TestBasePlot(GuiTestAssistant, unittest.TestCase, UnittestTools):
             mock_update.assert_called()
 
         self.plot._update_plot()
-        self.assertEqual((1.8, 4.2, 3.0, 3.0), self.plot._get_plot_range())
+        self.assertEqual((1.8, 4.2, 2.5, 3.5), self.plot._get_plot_range())
 
     def test_remove_value_names(self):
         self.analysis_model.header = ("density", "pressure")


### PR DESCRIPTION
Closes #369. Length of set is calculated before if-else ladder, as otherwise set would have to be called twice on a long list with a set size of 1.