### PR TITLE
CLN: Tidy up Application exit routines

### DIFF
--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -133,20 +133,6 @@ class TestWfManager(GuiTestAssistant, TestCase):
             self.assertEqual(self.wfmanager.windows[0].active_task,
                              self.setup_task)
 
-    def test_result_task_exit(self):
-        with self.create_tasks():
-            for window in self.wfmanager.windows:
-                window.close = mock.Mock(return_value=True)
-            self.review_task.exit()
-            self.assertTrue(self.review_task.window.close.called)
-
-    def test_setup_task_exit(self):
-        with self.create_tasks():
-            for window in self.wfmanager.windows:
-                window.close = mock.Mock(return_value=True)
-            self.setup_task.exit()
-            self.assertTrue(self.setup_task.window.close.called)
-
 
 class TestTaskWindowClosePrompt(TestCase):
 

--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -78,7 +78,7 @@ class TaskWindowClosePrompt(TaskWindow):
         setup_task = None
         for window in self.application.windows:
             for task in window.tasks:
-                if task.name == "Workflow Setup":
+                if task.id == "force_wfmanager.wfmanager_setup_task":
                     setup_task = task
         # If we don't have a setup task for some reason, just close
         if setup_task is None:

--- a/force_wfmanager/wfmanager_global_task.py
+++ b/force_wfmanager/wfmanager_global_task.py
@@ -1,14 +1,13 @@
 import logging
 
-from pyface.tasks.action.api import SMenu, SToolBar, TaskAction
 from pyface.api import ImageResource
-from traits.api import List
+from pyface.tasks.action.api import (
+    SMenu, SToolBar, TaskAction, SchemaAddition)
+from envisage.ui.tasks.task_extension import TaskExtension
+from traits.api import List, Callable
 
 from force_wfmanager.wfmanager import TaskToggleGroupAccelerator
 
-from traits.api import Callable
-from envisage.ui.tasks.task_extension import TaskExtension
-from pyface.tasks.action.api import SchemaAddition
 
 log = logging.getLogger(__name__)
 

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -63,10 +63,6 @@ class WfManagerReviewTask(Task):
         at the application level."""
         menu_bar = SMenuBar(
             SMenu(
-                TaskAction(name="Exit", method="exit", accelerator="Ctrl+Q"),
-                name="&Workflow Manager",
-            ),
-            SMenu(
                 TaskAction(
                     name="Open Workflow...",
                     method="setup_task.open_workflow",
@@ -93,8 +89,6 @@ class WfManagerReviewTask(Task):
                 TaskAction(
                     name="Plugins...", method="setup_task.open_plugins"
                 ),
-                TaskAction(name="Exit", method="exit"),
-                name="&File",
             ),
             SMenu(
                 TaskAction(
@@ -417,6 +411,3 @@ class WfManagerReviewTask(Task):
     def switch_task(self):
         if self.setup_task is not None:
             self.window.activate_task(self.setup_task)
-
-    def exit(self):
-        self.window.close()

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -54,7 +54,6 @@ class WfManagerReviewTask(Task):
         """A menu bar with functions relevant to the Review task.
         Functions associated to the shared methods are located
         at the application level."""
-
         return SMenuBar(id='mymenu')
 
     def _tool_bars_default(self):

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -303,7 +303,7 @@ class WfManagerReviewTask(Task):
     def sync_setup_task(self):
         if self.window is not None:
             for task in self.window.tasks:
-                if task.name == "Workflow Setup":
+                if task.id == "force_wfmanager.wfmanager_setup_task":
                     self.setup_task = task
                     self.analysis_model = self.setup_task.analysis_model
 

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -137,10 +137,6 @@ class WfManagerSetupTask(Task):
         """
         menu_bar = SMenuBar(
             SMenu(
-                TaskAction(name="Exit", method="exit", accelerator="Ctrl+Q"),
-                name="&Workflow Manager",
-            ),
-            SMenu(
                 TaskAction(
                     name="Open Workflow...",
                     method="open_workflow",
@@ -161,11 +157,6 @@ class WfManagerSetupTask(Task):
                     accelerator="Shift+Ctrl+S",
                 ),
                 TaskAction(name="Plugins...", method="open_plugins"),
-                TaskAction(name="Exit", method="exit"),
-                # NOTE: Setting id='File' here will automatically create
-                #       a exit menu item, I guess this is QT being 'helpful'.
-                #       This menu item calls application.exit, which bypasses
-                #       our custom exit which prompts for a save before exiting
                 name="&File",
             ),
             SMenu(
@@ -758,9 +749,6 @@ class WfManagerSetupTask(Task):
         """Switches to the review task and verifies startup setting are
         correct for toolbars/menus etc."""
         self.window.activate_task(self.review_task)
-
-    def exit(self):
-        self.window.close()
 
     # Custom UI Methods
     def ui_select(self):


### PR DESCRIPTION
## Description

### Related Issues
#374, #377 

### Summary
Implements the proposed change in #377  to remove the `File --> Exit` drop down item, and any routines in the `Task` level that exit the application.

Doing so reduces the current menu bar features from:

<img width="329" alt="Screenshot 2020-04-20 at 16 48 57" src="https://user-images.githubusercontent.com/50372949/79771564-e14ae800-8326-11ea-9d46-1c107f230c65.png">

to: 

<img width="329" alt="Screenshot 2020-04-20 at 16 50 56" src="https://user-images.githubusercontent.com/50372949/79771753-1e16df00-8327-11ea-8e25-ee05186e3bae.png">

### Notes
Although this reduces UI features, It removes code that was not appropriate for the application level it was being used.

Additionally, if the application is exited in any remaining way, a pop up window will still appear, prompting the user to save the workflow.

## Changes
- Removes `WfManagerSetupTask.exit` and `WfManagerReviewTask.exit` methods
- References to `task.name` now use `task.id` in methods that swap the display between `Task` objects