### PR TITLE
Revert params

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,6 +56,7 @@ def mock_modules():
 
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -54,6 +54,7 @@ def mock_modules():
 # General Configuration
 # ---------------------
 
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
@@ -66,20 +67,6 @@ extensions = [
     'sphinx.ext.napoleon',
     'traits.util.trait_documenter'
 ]
-
-try:
-    import enthought_sphinx_theme
-
-    html_theme_path = [enthought_sphinx_theme.theme_path]
-    html_theme = 'enthought'
-except ImportError as exc:
-    import warnings
-    msg = '''Can't find Enthought Sphinx Theme, using default.
-                Exception was: {}
-                Enthought Sphinx Theme can be downloaded from
-                https://github.com/enthought/enthought-sphinx-theme'''
-    warnings.warn(RuntimeWarning(msg.format(exc)))
-
 
 templates_path = ['_templates']
 source_suffix = '.rst'

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -192,7 +192,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
 
         # have ONLY two parameters been transferred?
         # (the third categorical parameter of the old_model
-        # should not be transferred as it is not allowed by the new model).
+        # should not be filtered out as it is not allowed by the new model).
         self.assertEqual(2, len(new_model.parameters))
         for p in new_model.parameters:
             self.assertNotIsInstance(p, CategoricalMCOParameter)

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -147,6 +147,10 @@ class TestWorkflowTree(WfManagerBaseTestCase):
 
         # create old model
         old_factory = DummyMCOFactory(plugin={'id': 'bcy356', 'name': 'old'})
+        old_factory.parameter_factory_classes = [
+            RangedVectorMCOParameterFactory,
+            RangedMCOParameterFactory
+        ]
         old_model = BaseMCOModel(factory=old_factory)
         old_model.parameters = [
             RangedMCOParameter(
@@ -163,6 +167,10 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         # create new model, that we want to transfer the parameters and
         # kpis to.
         new_factory = DummyMCOFactory(plugin={'id': 'xxui1', 'name': 'new'})
+        new_factory.parameter_factory_classes = [
+            RangedVectorMCOParameterFactory,
+            RangedMCOParameterFactory
+        ]
         new_model = BaseMCOModel(factory=new_factory)
 
         # workflow tree to work with

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -6,7 +6,13 @@ from force_bdss.api import (
     BaseMCOModel,
     KPISpecification,
     VerifierError,
+    RangedMCOParameter,
+    RangedMCOParameterFactory,
+    RangedVectorMCOParameter,
+    RangedVectorMCOParameterFactory,
 )
+
+from force_bdss.tests.dummy_classes.mco import DummyMCOFactory
 
 from force_wfmanager.tests.dummy_classes.dummy_mco_options_view import (
     DummyBaseMCOOptionsView,
@@ -136,6 +142,47 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         self.assertIsNone(self.system_state.add_new_entity)
         self.assertIsNone(self.system_state.remove_entity)
         self.assertIsNone(self.system_state.entity_creator)
+
+    def test_transfer_parameters(self):
+
+        # create old model
+        old_factory = DummyMCOFactory(plugin={'id': 'bcy356', 'name': 'old'})
+        old_model = BaseMCOModel(factory=old_factory)
+        old_model.parameters = [
+            RangedMCOParameter(
+                initial_value=1.0,
+                factory=RangedVectorMCOParameterFactory(old_factory)
+            ),
+            RangedVectorMCOParameter(
+                initial_value=[1.0, 1.0],
+                factory=RangedMCOParameterFactory(old_factory)
+            )
+        ]
+        old_model.kpis = []
+
+        # create new model, that we want to transfer the parameters and
+        # kpis to.
+        new_factory = DummyMCOFactory(plugin={'id': 'xxui1', 'name': 'new'})
+        new_model = BaseMCOModel(factory=new_factory)
+
+        # workflow tree to work with
+        workflow_tree = WorkflowTree(
+            model=Workflow(),
+            _factory_registry=self.factory_registry,
+            system_state=self.system_state,
+        )
+
+        # transfer the parameters and kpis
+        workflow_tree.transfer_parameters_and_kpis(old_model, new_model)
+
+        # have two parameters been transferred?
+        self.assertEqual(2, len(new_model.parameters))
+
+        # has the correct plugin id been transferred?
+        self.assertEqual(
+            'xxui1',
+            new_model.parameters[0].factory.mco_factory.plugin_id
+        )
 
     def test_new_mco(self):
 

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -10,6 +10,8 @@ from force_bdss.api import (
     RangedMCOParameterFactory,
     RangedVectorMCOParameter,
     RangedVectorMCOParameterFactory,
+    CategoricalMCOParameter,
+    CategoricalMCOParameterFactory
 )
 
 from force_bdss.tests.dummy_classes.mco import DummyMCOFactory
@@ -149,7 +151,8 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         old_factory = DummyMCOFactory(plugin={'id': 'bcy356', 'name': 'old'})
         old_factory.parameter_factory_classes = [
             RangedVectorMCOParameterFactory,
-            RangedMCOParameterFactory
+            RangedMCOParameterFactory,
+            CategoricalMCOParameterFactory
         ]
         old_model = BaseMCOModel(factory=old_factory)
         old_model.parameters = [
@@ -160,6 +163,10 @@ class TestWorkflowTree(WfManagerBaseTestCase):
             RangedVectorMCOParameter(
                 initial_value=[1.0, 1.0],
                 factory=RangedMCOParameterFactory(old_factory)
+            ),
+            CategoricalMCOParameter(
+                categories=['A', 'B', 'C'],
+                factory=CategoricalMCOParameterFactory(old_factory)
             )
         ]
         old_model.kpis = []
@@ -169,7 +176,7 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         new_factory = DummyMCOFactory(plugin={'id': 'xxui1', 'name': 'new'})
         new_factory.parameter_factory_classes = [
             RangedVectorMCOParameterFactory,
-            RangedMCOParameterFactory
+            RangedMCOParameterFactory,
         ]
         new_model = BaseMCOModel(factory=new_factory)
 
@@ -183,8 +190,12 @@ class TestWorkflowTree(WfManagerBaseTestCase):
         # transfer the parameters and kpis
         workflow_tree.transfer_parameters_and_kpis(old_model, new_model)
 
-        # have two parameters been transferred?
+        # have ONLY two parameters been transferred?
+        # (the third categorical parameter of the old_model
+        # should not be transferred as it is not allowed by the new model).
         self.assertEqual(2, len(new_model.parameters))
+        for p in new_model.parameters:
+            self.assertNotIsInstance(p, CategoricalMCOParameter)
 
         # has the correct plugin id been transferred?
         self.assertEqual(

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -654,11 +654,6 @@ class WorkflowTree(ModelView):
         new_model: BaseMCOModel
             The new model, to which you want to transfer the parameters/kpis.
 
-        Afterall the user might want to change the optimizer,
-        # but keep the same parameters and kpis.
-        # model = Workflow
-        # Set the new model's parameters and kpis to that of the old.
-
         Raises
         ------
         AttributeError

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -673,10 +673,13 @@ class WorkflowTree(ModelView):
         This is done by calling MCOParameterFactory(<new MCOFactory>).
         """
         try:
+            new_factory = new_model.factory
             params_new = []
             for p in old_model.parameters:
-                p.factory = p.factory.__class__(new_model.factory)
-                params_new.append(p)
+                for factory_cls in new_factory.parameter_factory_classes:
+                    if isinstance(p.factory, factory_cls):
+                        p.factory = factory_cls(new_factory)
+                        params_new.append(p)
             new_model.parameters = params_new
             new_model.kpis = [k for k in old_model.kpis]
         except AttributeError:


### PR DESCRIPTION
## Description

When the user selects a new MCO, the parameters and kpis are wiped and then the user has to
set them again. (#381). This makes a small change to `WorkflowTree.new_mco()`, so that the new MCO's parameters and kpis are set to those of the old MCO.

### Related Issues
#381

## Changes
This makes a small change to `WorkflowTree.new_mco()`, that sets the new MCO's parameters and kpis to those of the old MCO. The kpis can just be copied as they are self-contained. Each parameter refers to the MCOModel and plugin (via their factories) and these are changed appropriately.

