### PR TITLE
copyright header

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import click
 import os
 import shutil

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 #
 # FORCE documentation build configuration file, created by
 # sphinx-quickstart on Mon Feb 02 16:26:16 2015.

--- a/force_wfmanager/__init__.py
+++ b/force_wfmanager/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/gui/__init__.py
+++ b/force_wfmanager/gui/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/gui/run.py
+++ b/force_wfmanager/gui/run.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import click
 

--- a/force_wfmanager/gui/tests/__init__.py
+++ b/force_wfmanager/gui/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/gui/tests/test_click_run.py
+++ b/force_wfmanager/gui/tests/test_click_run.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import sys
 import os

--- a/force_wfmanager/gui/tests/test_run.py
+++ b/force_wfmanager/gui/tests/test_run.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from unittest import mock
 

--- a/force_wfmanager/io/analysis_model_io.py
+++ b/force_wfmanager/io/analysis_model_io.py
@@ -1,3 +1,7 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
+
 def write_analysis_model(analysis_model, file_path):
     """ Write the contents of the analysis model to a JSON or CSV file.
 

--- a/force_wfmanager/io/project_io.py
+++ b/force_wfmanager/io/project_io.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import json
 

--- a/force_wfmanager/io/workflow_io.py
+++ b/force_wfmanager/io/workflow_io.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from force_bdss.api import WorkflowWriter, WorkflowReader

--- a/force_wfmanager/model/__init__.py
+++ b/force_wfmanager/model/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/model/analysis_model.py
+++ b/force_wfmanager/model/analysis_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import csv
 import json
 import logging

--- a/force_wfmanager/model/tests/__init__.py
+++ b/force_wfmanager/model/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/model/tests/test_analysis_model.py
+++ b/force_wfmanager/model/tests/test_analysis_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import json
 import tempfile
 from testfixtures import LogCapture

--- a/force_wfmanager/notifications/__init__.py
+++ b/force_wfmanager/notifications/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/notifications/tests/__init__.py
+++ b/force_wfmanager/notifications/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/notifications/tests/test_ui_notification.py
+++ b/force_wfmanager/notifications/tests/test_ui_notification.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from testfixtures import LogCapture
 from threading import Event

--- a/force_wfmanager/notifications/tests/test_ui_notification_factory.py
+++ b/force_wfmanager/notifications/tests/test_ui_notification_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_wfmanager.notifications.ui_notification import \

--- a/force_wfmanager/notifications/tests/test_ui_notification_hooks_factory.py
+++ b/force_wfmanager/notifications/tests/test_ui_notification_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_wfmanager.notifications.ui_notification_hooks_manager \

--- a/force_wfmanager/notifications/tests/test_ui_notification_hooks_manager.py
+++ b/force_wfmanager/notifications/tests/test_ui_notification_hooks_manager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from pyface.tasks.task import Task

--- a/force_wfmanager/notifications/tests/test_ui_notification_plugin.py
+++ b/force_wfmanager/notifications/tests/test_ui_notification_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_wfmanager.notifications.ui_notification_factory import \

--- a/force_wfmanager/notifications/ui_notification.py
+++ b/force_wfmanager/notifications/ui_notification.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import zmq

--- a/force_wfmanager/notifications/ui_notification_factory.py
+++ b/force_wfmanager/notifications/ui_notification_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Bool
 
 from force_bdss.api import BaseNotificationListenerFactory

--- a/force_wfmanager/notifications/ui_notification_hooks_factory.py
+++ b/force_wfmanager/notifications/ui_notification_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseUIHooksFactory
 
 from .ui_notification_hooks_manager import UINotificationHooksManager

--- a/force_wfmanager/notifications/ui_notification_hooks_manager.py
+++ b/force_wfmanager/notifications/ui_notification_hooks_manager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseUIHooksManager, factory_id
 
 from .ui_notification_model import UINotificationModel

--- a/force_wfmanager/notifications/ui_notification_model.py
+++ b/force_wfmanager/notifications/ui_notification_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Str
 
 from force_bdss.api import BaseNotificationListenerModel

--- a/force_wfmanager/notifications/ui_notification_plugin.py
+++ b/force_wfmanager/notifications/ui_notification_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseExtensionPlugin, plugin_id
 
 from .ui_notification_factory import UINotificationFactory

--- a/force_wfmanager/plugins/__init__.py
+++ b/force_wfmanager/plugins/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/plugins/plugin_dialog.py
+++ b/force_wfmanager/plugins/plugin_dialog.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     HasStrictTraits, List, Instance, Str,
     on_trait_change

--- a/force_wfmanager/plugins/tests/__init__.py
+++ b/force_wfmanager/plugins/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/plugins/tests/test_plugin_dialog.py
+++ b/force_wfmanager/plugins/tests/test_plugin_dialog.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 import testfixtures
 

--- a/force_wfmanager/plugins/tests/test_wfmanager_plugin.py
+++ b/force_wfmanager/plugins/tests/test_wfmanager_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from unittest import mock
 

--- a/force_wfmanager/plugins/wfmanager_plugin.py
+++ b/force_wfmanager/plugins/wfmanager_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.api import Plugin
 from envisage.ui.tasks.api import TaskFactory
 from traits.api import Either, List, Str

--- a/force_wfmanager/server/__init__.py
+++ b/force_wfmanager/server/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/server/tests/__init__.py
+++ b/force_wfmanager/server/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/server/tests/test_zmq_server.py
+++ b/force_wfmanager/server/tests/test_zmq_server.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import json
 import logging
 import unittest

--- a/force_wfmanager/server/zmq_server.py
+++ b/force_wfmanager/server/zmq_server.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import threading
 

--- a/force_wfmanager/tests/__init__.py
+++ b/force_wfmanager/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/tests/dummy_classes/__init__.py
+++ b/force_wfmanager/tests/dummy_classes/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/tests/dummy_classes/dummy_contributed_ui.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_contributed_ui.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traitsui.api import Item, VGroup
 
 from force_bdss.api import plugin_id, Workflow

--- a/force_wfmanager/tests/dummy_classes/dummy_data_view.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traitsui.group import VGroup
 from traitsui.view import View
 

--- a/force_wfmanager/tests/dummy_classes/dummy_factory.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.data_sources.base_data_source_factory import (
     BaseDataSourceFactory
 )

--- a/force_wfmanager/tests/dummy_classes/dummy_mco_options_view.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_mco_options_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_wfmanager.ui.setup.mco.base_mco_options_view import \
     BaseMCOOptionsView
 

--- a/force_wfmanager/tests/dummy_classes/dummy_model_info.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_model_info.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.has_traits import HasTraits
 from traits.trait_types import Instance
 

--- a/force_wfmanager/tests/dummy_classes/dummy_wfmanager.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_wfmanager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.core_plugin import CorePlugin
 from envisage.ui.tasks.tasks_plugin import TasksPlugin
 

--- a/force_wfmanager/tests/fixtures/__init__.py
+++ b/force_wfmanager/tests/fixtures/__init__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from os.path import join, dirname, abspath
 
 

--- a/force_wfmanager/tests/mock_methods.py
+++ b/force_wfmanager/tests/mock_methods.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import subprocess
 from unittest import mock
 

--- a/force_wfmanager/tests/probe_classes.py
+++ b/force_wfmanager/tests/probe_classes.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.core_plugin import CorePlugin
 from envisage.ui.tasks.tasks_plugin import TasksPlugin
 

--- a/force_wfmanager/tests/test_wfmanager.py
+++ b/force_wfmanager/tests/test_wfmanager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import contextlib
 import os
 import shutil

--- a/force_wfmanager/tests/test_wfmanager_review_task.py
+++ b/force_wfmanager/tests/test_wfmanager_review_task.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import mock, TestCase
 
 from pyface.constant import OK

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import mock, TestCase
 import subprocess
 from testfixtures import LogCapture

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import copy
 from unittest import mock, TestCase
 

--- a/force_wfmanager/tests/utils.py
+++ b/force_wfmanager/tests/utils.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import time
 
 

--- a/force_wfmanager/ui/__init__.py
+++ b/force_wfmanager/ui/__init__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .contributed_ui.contributed_ui import ContributedUI  # noqa
 from .contributed_ui.contributed_ui import ContributedUIHandler  # noqa
 from .contributed_ui.i_contributed_ui import IContributedUI  # noqa

--- a/force_wfmanager/ui/contributed_ui/__init__.py
+++ b/force_wfmanager/ui/contributed_ui/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/contributed_ui/contributed_ui.py
+++ b/force_wfmanager/ui/contributed_ui/contributed_ui.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import re
 
 from traits.api import (

--- a/force_wfmanager/ui/contributed_ui/i_contributed_ui.py
+++ b/force_wfmanager/ui/contributed_ui/i_contributed_ui.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Dict, Event, Instance, Int, Interface, Str
 from traitsui.api import Action, Group
 

--- a/force_wfmanager/ui/contributed_ui/tests/__init__.py
+++ b/force_wfmanager/ui/contributed_ui/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/contributed_ui/tests/test_contributed_ui.py
+++ b/force_wfmanager/ui/contributed_ui/tests/test_contributed_ui.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from functools import partial
 

--- a/force_wfmanager/ui/contributed_ui/tests/test_ui_select_modal.py
+++ b/force_wfmanager/ui/contributed_ui/tests/test_ui_select_modal.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant

--- a/force_wfmanager/ui/contributed_ui/ui_select_modal.py
+++ b/force_wfmanager/ui/contributed_ui/ui_select_modal.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from collections import defaultdict
 
 from traits.api import (

--- a/force_wfmanager/ui/review/__init__.py
+++ b/force_wfmanager/ui/review/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/review/base_data_view.py
+++ b/force_wfmanager/ui/review/base_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Bool,
     Instance,

--- a/force_wfmanager/ui/review/data_view_pane.py
+++ b/force_wfmanager/ui/review/data_view_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from pyface.tasks.api import TraitsTaskPane
 from traits.api import (
     Button,

--- a/force_wfmanager/ui/review/i_base_plot.py
+++ b/force_wfmanager/ui/review/i_base_plot.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from chaco.api import ArrayDataSource
 from traits.api import Instance
 

--- a/force_wfmanager/ui/review/i_data_view.py
+++ b/force_wfmanager/ui/review/i_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Interface, Instance, Bool
 
 from force_wfmanager.model.analysis_model import AnalysisModel

--- a/force_wfmanager/ui/review/plot.py
+++ b/force_wfmanager/ui/review/plot.py
@@ -8,6 +8,9 @@
   optional colourmap to be applied to a third variable.
 
 """
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from chaco.api import ArrayPlotData, ArrayDataSource, ScatterInspectorOverlay

--- a/force_wfmanager/ui/review/results_pane.py
+++ b/force_wfmanager/ui/review/results_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from pyface.tasks.api import TraitsDockPane
 from traits.api import Instance
 from traitsui.api import VGroup, View, UItem

--- a/force_wfmanager/ui/review/results_table.py
+++ b/force_wfmanager/ui/review/results_table.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Either,
     HasStrictTraits,

--- a/force_wfmanager/ui/review/tests/__init__.py
+++ b/force_wfmanager/ui/review/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/review/tests/test_base_data_view.py
+++ b/force_wfmanager/ui/review/tests/test_base_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from traits.testing.api import UnittestTools

--- a/force_wfmanager/ui/review/tests/test_data_view_pane.py
+++ b/force_wfmanager/ui/review/tests/test_data_view_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import mock
 import unittest
 

--- a/force_wfmanager/ui/review/tests/test_plot.py
+++ b/force_wfmanager/ui/review/tests/test_plot.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import mock
 import unittest
 import warnings

--- a/force_wfmanager/ui/review/tests/test_results_pane.py
+++ b/force_wfmanager/ui/review/tests/test_results_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_wfmanager.model.analysis_model import AnalysisModel

--- a/force_wfmanager/ui/review/tests/test_results_table.py
+++ b/force_wfmanager/ui/review/tests/test_results_table.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_wfmanager.model.analysis_model import AnalysisModel

--- a/force_wfmanager/ui/setup/__init__.py
+++ b/force_wfmanager/ui/setup/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/communicator/__init__.py
+++ b/force_wfmanager/ui/setup/communicator/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/communicator/communicator_view.py
+++ b/force_wfmanager/ui/setup/communicator/communicator_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Instance, List, on_trait_change, Event, HasTraits
 )

--- a/force_wfmanager/ui/setup/communicator/notification_listener_view.py
+++ b/force_wfmanager/ui/setup/communicator/notification_listener_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Instance, Str, Bool, Event, HasTraits
 )

--- a/force_wfmanager/ui/setup/communicator/tests/__init__.py
+++ b/force_wfmanager/ui/setup/communicator/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/communicator/tests/test_communicator_view.py
+++ b/force_wfmanager/ui/setup/communicator/tests/test_communicator_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.api import Workflow

--- a/force_wfmanager/ui/setup/communicator/tests/test_notification_listener_view.py
+++ b/force_wfmanager/ui/setup/communicator/tests/test_notification_listener_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.tests.probe_classes.notification_listener import \

--- a/force_wfmanager/ui/setup/mco/__init__.py
+++ b/force_wfmanager/ui/setup/mco/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/mco/base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/base_mco_options_model_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Bool, Event, Instance, List, Property, Str,
     on_trait_change, Either, Tuple

--- a/force_wfmanager/ui/setup/mco/base_mco_options_view.py
+++ b/force_wfmanager/ui/setup/mco/base_mco_options_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Bool, Event, Instance, List, Str,
     on_trait_change, HasTraits, Property

--- a/force_wfmanager/ui/setup/mco/kpi_specification_model_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_model_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Property, Str, on_trait_change
 )

--- a/force_wfmanager/ui/setup/mco/kpi_specification_view.py
+++ b/force_wfmanager/ui/setup/mco/kpi_specification_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     List, Property, Str, cached_property,
     on_trait_change, Button

--- a/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_model_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     cached_property, Property, Str, on_trait_change
 )

--- a/force_wfmanager/ui/setup/mco/mco_parameter_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_parameter_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Instance, Str, on_trait_change, Property,
     cached_property, List, Button, Tuple

--- a/force_wfmanager/ui/setup/mco/mco_view.py
+++ b/force_wfmanager/ui/setup/mco/mco_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Instance, List, Str, on_trait_change, Bool, Event,
     HasTraits

--- a/force_wfmanager/ui/setup/mco/tests/__init__.py
+++ b/force_wfmanager/ui/setup/mco/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_model_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.testing.unittest_tools import UnittestTools

--- a/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_base_mco_options_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.testing.unittest_tools import UnittestTools

--- a/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_model_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from traits.testing.unittest_tools import UnittestTools
 

--- a/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_kpi_specification_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.testing.unittest_tools import UnittestTools

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_model_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_model_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from traits.testing.unittest_tools import UnittestTools
 

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_parameter_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.testing.unittest_tools import UnittestTools

--- a/force_wfmanager/ui/setup/mco/tests/test_mco_view.py
+++ b/force_wfmanager/ui/setup/mco/tests/test_mco_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.testing.unittest_tools import UnittestTools
 
 from force_bdss.api import (

--- a/force_wfmanager/ui/setup/new_entity_creator.py
+++ b/force_wfmanager/ui/setup/new_entity_creator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Bool, Callable, Dict, Either, HasStrictTraits, Instance, List, ReadOnly,
     Property, Str, on_trait_change

--- a/force_wfmanager/ui/setup/process/__init__.py
+++ b/force_wfmanager/ui/setup/process/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/process/data_source_view.py
+++ b/force_wfmanager/ui/setup/process/data_source_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     HasStrictTraits, Instance, List, Int, on_trait_change,
     Bool, HTML, Property, Event, Str, HasTraits,

--- a/force_wfmanager/ui/setup/process/execution_layer_view.py
+++ b/force_wfmanager/ui/setup/process/execution_layer_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     Instance, Str, Bool, on_trait_change, List, Int,
     Event, HasTraits

--- a/force_wfmanager/ui/setup/process/process_view.py
+++ b/force_wfmanager/ui/setup/process/process_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     HasTraits, Instance, List, on_trait_change, Bool, Event, Str
 )

--- a/force_wfmanager/ui/setup/process/tests/__init__.py
+++ b/force_wfmanager/ui/setup/process/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_data_source_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.testing.unittest_tools import UnittestTools
 
 from force_bdss.api import OutputSlotInfo, InputSlotInfo, BaseDataSourceModel

--- a/force_wfmanager/ui/setup/process/tests/test_execution_layer_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_execution_layer_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_wfmanager.ui.setup.process.execution_layer_view import (
     ExecutionLayerView
 )

--- a/force_wfmanager/ui/setup/process/tests/test_process_view.py
+++ b/force_wfmanager/ui/setup/process/tests/test_process_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_wfmanager.ui.setup.process.process_view import (
     ProcessView
 )

--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from pyface.tasks.api import TraitsTaskPane
 from traits.api import (
     Bool, Button, Instance, Property, Str,

--- a/force_wfmanager/ui/setup/side_pane.py
+++ b/force_wfmanager/ui/setup/side_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from pyface.tasks.api import TraitsDockPane
 from traits.api import Bool, Button, Instance, on_trait_change
 from traitsui.api import UItem, VGroup, View

--- a/force_wfmanager/ui/setup/system_state.py
+++ b/force_wfmanager/ui/setup/system_state.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     HasTraits, Instance, Str, Callable
 )

--- a/force_wfmanager/ui/setup/tests/__init__.py
+++ b/force_wfmanager/ui/setup/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
+++ b/force_wfmanager/ui/setup/tests/test_new_entity_creator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.tests.dummy_classes.data_source import DummyDataSourceModel

--- a/force_wfmanager/ui/setup/tests/test_setup_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_setup_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant

--- a/force_wfmanager/ui/setup/tests/test_side_pane.py
+++ b/force_wfmanager/ui/setup/tests/test_side_pane.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_wfmanager.ui.setup.side_pane import SidePane
 from force_wfmanager.ui.setup.system_state import SystemState
 from force_wfmanager.ui.setup.tests.wfmanager_base_test_case import (

--- a/force_wfmanager/ui/setup/tests/test_system_state.py
+++ b/force_wfmanager/ui/setup/tests/test_system_state.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_wfmanager.ui.setup.system_state import SystemState

--- a/force_wfmanager/ui/setup/tests/test_workflow_info.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_info.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import (
     KPISpecification, OutputSlotInfo
 )

--- a/force_wfmanager/ui/setup/tests/test_workflow_tree.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_tree.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import mock, TestCase
 
 from force_bdss.api import (

--- a/force_wfmanager/ui/setup/tests/test_workflow_view.py
+++ b/force_wfmanager/ui/setup/tests/test_workflow_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.testing.unittest_tools import UnittestTools
 
 from force_bdss.api import (

--- a/force_wfmanager/ui/setup/tests/wfmanager_base_test_case.py
+++ b/force_wfmanager/ui/setup/tests/wfmanager_base_test_case.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.api import (

--- a/force_wfmanager/ui/setup/workflow_info.py
+++ b/force_wfmanager/ui/setup/workflow_info.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from envisage.plugin import Plugin
 from pyface.api import ImageResource
 

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from functools import partial, wraps
 
 from traits.api import (

--- a/force_wfmanager/ui/setup/workflow_view.py
+++ b/force_wfmanager/ui/setup/workflow_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import (
     HasTraits, List, Instance, Str, on_trait_change, Bool, Event
 )

--- a/force_wfmanager/ui/tests/__init__.py
+++ b/force_wfmanager/ui/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/ui/tests/test_custom_ui_plugin.py
+++ b/force_wfmanager/ui/tests/test_custom_ui_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from envisage.core_plugin import CorePlugin

--- a/force_wfmanager/ui/tests/test_ui_utils.py
+++ b/force_wfmanager/ui/tests/test_ui_utils.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.tests.dummy_classes.extension_plugin import (

--- a/force_wfmanager/ui/ui_utils.py
+++ b/force_wfmanager/ui/ui_utils.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from pyface.qt import QtGui
 from traitsui.api import Group, Item
 

--- a/force_wfmanager/utils/__init__.py
+++ b/force_wfmanager/utils/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/utils/local_traits.py
+++ b/force_wfmanager/utils/local_traits.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import re
 
 from traits.api import BaseStr, HasStrictTraits, TraitError

--- a/force_wfmanager/utils/tests/__init__.py
+++ b/force_wfmanager/utils/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/force_wfmanager/utils/tests/test_local_traits.py
+++ b/force_wfmanager/utils/tests/test_local_traits.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traits.api import HasStrictTraits, TraitError

--- a/force_wfmanager/utils/tests/test_variable_names_registry.py
+++ b/force_wfmanager/utils/tests/test_variable_names_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from force_bdss.api import OutputSlotInfo, InputSlotInfo, ExecutionLayer

--- a/force_wfmanager/utils/variable_names_registry.py
+++ b/force_wfmanager/utils/variable_names_registry.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from traits.api import (

--- a/force_wfmanager/wfmanager.py
+++ b/force_wfmanager/wfmanager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from envisage.ui.tasks.api import TasksApplication, TaskWindow

--- a/force_wfmanager/wfmanager_global_task.py
+++ b/force_wfmanager/wfmanager_global_task.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from pyface.api import ImageResource

--- a/force_wfmanager/wfmanager_review_task.py
+++ b/force_wfmanager/wfmanager_review_task.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from pyface.api import ImageResource, FileDialog, OK, error

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from concurrent.futures import ThreadPoolExecutor
 import os
 import logging

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import os
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
## Description
Add Enthought open source copyright header to every file.

## Related Issues
https://github.com/force-h2020/force-bdss/pull/351

### Notes
The headers were inserted automatically using PyCharm's Copyright Profile functionality. The only problem is that it ends up creating two blank lines at the end of blank  _init_.py module files, which then don't pass flake8, so the extra line has to be removed manually.

## Changes
Just the header on each file
