### PR TITLE
MAINT: Update to Pyface and TraitsUI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b maint/update-traits
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git -b maint/update-traits
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -10,14 +10,14 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
-    "pyface==6.1.2-5",
+    "pyface==7.0.0-3",
     "pygments==2.2.0-1",
     "pyqt==4.11.4-7",
     "qt==4.8.7-10",
     "sip==4.17-4",
-    "traitsui==6.1.3-5",
-    "numpy==1.15.4-2",
-    "chaco==4.8.0-1",
+    "traitsui==7.0.0-2",
+    "numpy>=1.15.4-2",
+    "chaco==4.8.0-4",
     "pyzmq==16.0.0-7",
     "mock==2.0.0-3"
 ]


### PR DESCRIPTION
## Description

Bumps TraitsUI (plus Pyface, Chaco) version to support Traits 6.1.0

Should NOT be merged before https://github.com/force-h2020/force-bdss/pull/356

### Summary
Envisage dependency now a `4.9.2-3`

### Future Work
- Exploring new features in traits 6.1.0 (`observe` functionality)

## Changes
- Dependency bump: `pyface==7.0.0-3`,  `traitsui==7.0.0-2`, `chaco==4.8.0-4`