### PR TITLE
PyQt 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,6 @@ matrix:
       - EDM_INSTALLER_PREFIX="edm_"
         EDM_INSTALLER_SUFFIX=".pkg"
 
-addons:
-  apt:
-    packages:
-    - libxkbcommon-x11-0
-    - libxcb-icccm4
-
 before_install:
     - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
       - EDM_INSTALLER_PREFIX="edm_"
         EDM_INSTALLER_SUFFIX=".pkg"
 
+addons:
+  apt:
+    packages:
+    - libxkbcommon-x11-0
+    - libxcb-icccm4
+
 before_install:
     - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -10,12 +10,12 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
-    "pyface>=6.1.2-5",
+    "pyface==7.0.0-3",
     "pygments==2.2.0-1",
     "pyqt5==5.14.2-3",
     "sip==4.17-4",
-    "traits>=6.0.0-1",
-    "traitsui==7.0.0-1",
+    "traits==6.1.0-1",
+    "traitsui==7.0.0-2",
     "numpy>=1.15.4-2",
     "chaco>=4.8.0-1",
     "pyzmq==16.0.0-7",

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -10,14 +10,14 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
-    "pyface==7.0.0-3",
+    "pyface>=6.1.2-5",
     "pygments==2.2.0-1",
-    "pyqt==4.11.4-7",
-    "qt==4.8.7-10",
+    "pyqt5==5.14.2-3",
     "sip==4.17-4",
-    "traitsui==7.0.0-2",
+    "traits>=6.0.0-1",
+    "traitsui==7.0.0-1",
     "numpy>=1.15.4-2",
-    "chaco==4.8.0-4",
+    "chaco>=4.8.0-1",
     "pyzmq==16.0.0-7",
     "mock==2.0.0-3"
 ]


### PR DESCRIPTION
## Description
Update of the dependencies from PyQt 4 to 5.

### Background
Enthought libraries (Traits/etc) will no longer be maintained for PyQt 4 dependence.


## Changes
- `ADDITIONAL_CORE_DEPS` in `ci/main.py` changed so that PyQt5 is used and other dependencies upgraded around this.
