### PR TITLE
ENH: Include MathJax in new entity creator HTML header

### DIFF
--- a/force_wfmanager/ui/setup/new_entity_creator.py
+++ b/force_wfmanager/ui/setup/new_entity_creator.py
@@ -358,6 +358,9 @@ def htmlformat(factory_title=None, factory_description=None,
                     display: block;
                 }}
             </style>
+        <script type="text/javascript" id="MathJax-script" async
+          src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        </script>
         </head>
         <body>
             {body}


### PR DESCRIPTION
## Description

Includes MathJax support in the `NewEntityCreator` view

### Related Issues
Closes #399 

### Summary
Adds a script that installs MathJax to the HTML code header when rendering factor descriptions in the new entity creation

### Notes
From what I can tell TraitsUI `HTMLEditor` only supports MathJax v 2.7.1

## Changes
- Includes support for MathJax formatted text in New Entity Creator
