### PR TITLE
ENH: include scrollable workaround to prevent UI from resizing

### DIFF
--- a/force_wfmanager/ui/setup/setup_pane.py
+++ b/force_wfmanager/ui/setup/setup_pane.py
@@ -220,9 +220,10 @@ class SetupPane(TraitsTaskPane):
                             show_border=True,
                         ),
                     ),
-                    enabled_when="ui_enabled"
+                    enabled_when="ui_enabled",
                 ),
             ),
+            scrollable=True,
             width=500,
         )
 

--- a/force_wfmanager/ui/setup/workflow_tree.py
+++ b/force_wfmanager/ui/setup/workflow_tree.py
@@ -366,6 +366,7 @@ class WorkflowTree(ModelView):
             ),
             width=500,
             resizable=True,
+            scrollable=True,
         )
 
         return view


### PR DESCRIPTION
## Description

Provides a workaround to #382 

### Related Issues
Closes #382 

### Summary
Includes scrollable options on setup and side pane views so that they do not automatically resize on selection of objects.

Also tested on Simphony-Remote - prevents the screen from expanding outside the browser display

