### PR TITLE
ENH: Add CurveScatterPlot as a default plot type

### DIFF
--- a/force_wfmanager/tests/test_wfmanager_review_task.py
+++ b/force_wfmanager/tests/test_wfmanager_review_task.py
@@ -101,14 +101,14 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
     def test_default_data_views(self):
         # Test of the data view selection feature within the task.
 
-        # A single default plot type
+        # Two default plot types
         self.assertEqual(
-            len(self.review_task.central_pane.available_data_views), 1
+            2, len(self.review_task.central_pane.available_data_views)
         )
 
         # Initial state
         self.assertEqual(
-            self.review_task.central_pane.data_view_selection, Plot
+            Plot, self.review_task.central_pane.data_view_selection
         )
         self.assertIsInstance(self.review_task.central_pane.data_view, Plot)
 
@@ -130,9 +130,9 @@ class TestWFManagerTasksWithPlugins(GuiTestAssistant, TestCase):
         )
 
     def test_discover_data_views(self):
-        # One default plot type plus three contributed
+        # Twp default plot types plus three contributed
         self.assertEqual(
-            4, len(self.review_task.central_pane.available_data_views),
+            5, len(self.review_task.central_pane.available_data_views),
         )
 
         # fire the button to populate descriptions

--- a/force_wfmanager/ui/review/curve_scatter_plot.py
+++ b/force_wfmanager/ui/review/curve_scatter_plot.py
@@ -20,6 +20,9 @@ _ERROR = 'Unable to interpolate curve through data points'
 
 class CurveScatterPlot(Plot):
 
+    #: Short description for the UI selection
+    description = "Scatter plot with curve overlay"
+
     #: Toggle to determine whether to overlay curve in the display
     toggle_display_curve = Bool()
 

--- a/force_wfmanager/ui/review/curve_scatter_plot.py
+++ b/force_wfmanager/ui/review/curve_scatter_plot.py
@@ -1,0 +1,119 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
+import logging
+
+import numpy as np
+from scipy import interpolate
+
+from chaco.api import BaseXYPlot
+from traits.api import Instance, on_trait_change, Str, Bool
+from traitsui.api import (
+    HGroup, Item, UItem, VGroup, UReadonly, EnumEditor)
+
+from force_wfmanager.ui.review.plot import Plot
+
+log = logging.getLogger(__name__)
+
+_ERROR = 'Unable to interpolate curve through data points'
+
+
+class CurveScatterPlot(Plot):
+
+    #: Toggle to determine whether to overlay curve in the display
+    toggle_display_curve = Bool()
+
+    _curve_axis = Instance(BaseXYPlot)
+
+    #: Whether the curve interpolation is successful or not with the
+    #: displayed data
+    _curve_status = Bool()
+
+    #: Error message to display
+    _curve_error = Str()
+
+    def _axis_hgroup_default(self):
+        return HGroup(
+            Item("x", editor=EnumEditor(name="displayable_value_names")),
+            Item("y", editor=EnumEditor(name="displayable_value_names")),
+            UItem("color_options"),
+            VGroup(
+                Item("toggle_automatic_update", label="Axis auto update"),
+                Item("toggle_display_curve", label="Display curve"),
+                UReadonly("_curve_error", visible_when="not _curve_status")
+            )
+        )
+
+    def _get_plot_data_default(self):
+        """Extends plot data objects to add a dimension for the curve"""
+        plot_data = super(CurveScatterPlot, self)._get_plot_data_default()
+        plot_data.set_data("x_curve", [])
+        plot_data.set_data("y_curve", [])
+        return plot_data
+
+    @on_trait_change("toggle_display_curve")
+    def _update_curve_plot(self):
+        """Updates curve line plot. Will attempt to interpolate a curve through
+        the 2D data, and flag an error to display in the UI if fails.
+        """
+
+        if (
+                self.x == ""
+                or self.y == ""
+                or self.analysis_model.is_empty
+                or not self.toggle_display_curve
+        ):
+            self._plot_data.set_data("x_curve", [])
+            self._plot_data.set_data("y_curve", [])
+            self._curve_status = True
+            return
+
+        x = self._plot_data.get_data("x")
+        y = self._plot_data.get_data("y")
+
+        # Attempt to fit curve, reset the curves and display an error
+        # if this fails
+        try:
+            f = interpolate.interp1d(x, y)
+            x_curve = np.linspace(min(x), max(x), 20)
+            y_curve = f(x_curve)
+
+            self._plot_data.set_data("x_curve", x_curve)
+            self._plot_data.set_data("y_curve", y_curve)
+            self._curve_status = True
+        except (TypeError, ValueError):
+            self._plot_data.set_data("x_curve", [])
+            self._plot_data.set_data("y_curve", [])
+            self._curve_status = False
+
+    def _add_curve(self, plot):
+        """Adds a curve line plot to the ChacoPlot"""
+        curve_plot = plot.plot(
+            ("x_curve", "y_curve"),
+            type="line",
+            color="red"
+        )[0]
+        self._curve_axis = curve_plot
+
+    def _update_plot(self):
+        """Overloads the parent class method to update the curve plot"""
+        super(CurveScatterPlot, self)._update_plot()
+        self._update_curve_plot()
+
+    @on_trait_change("x")
+    def _update_plot_x_axis(self):
+        """Overload the parent class method to update the curve plot"""
+        super(CurveScatterPlot, self)._update_plot_x_axis()
+        self._update_curve_plot()
+
+    @on_trait_change("y")
+    def _update_plot_y_axis(self):
+        """Overload the parent class method to update the curve plot"""
+        super(CurveScatterPlot, self)._update_plot_y_axis()
+        self._update_curve_plot()
+
+    def plot_scatter(self):
+        """Overload the parent class method to add the curve plot"""
+        plot = super(CurveScatterPlot, self).plot_scatter()
+        self._add_curve(plot)
+        return plot

--- a/force_wfmanager/ui/review/data_view_pane.py
+++ b/force_wfmanager/ui/review/data_view_pane.py
@@ -87,7 +87,7 @@ class DataViewPane(TraitsTaskPane):
         to extract their custom data views.
 
         """
-        # "Plot" and "CurveScatterPlot" are added first as they serves as
+        # "Plot" and "CurveScatterPlot" are added first as they serve as
         # the default selection.
         available_data_views = [Plot, CurveScatterPlot]
         if self.task is not None and self.task.window is not None:

--- a/force_wfmanager/ui/review/data_view_pane.py
+++ b/force_wfmanager/ui/review/data_view_pane.py
@@ -16,6 +16,7 @@ from traitsui.api import EnumEditor, HGroup, UItem, VGroup, View
 
 from force_wfmanager.model.analysis_model import AnalysisModel
 from force_wfmanager.ui.review.plot import Plot
+from force_wfmanager.ui.review.curve_scatter_plot import CurveScatterPlot
 from force_wfmanager.ui.review.base_data_view import BaseDataView
 from force_wfmanager.ui.ui_utils import class_description
 
@@ -86,8 +87,9 @@ class DataViewPane(TraitsTaskPane):
         to extract their custom data views.
 
         """
-        # "Plot" is added first as it serves as the default selection.
-        available_data_views = [Plot]
+        # "Plot" and "CurveScatterPlot" are added first as they serves as
+        # the default selection.
+        available_data_views = [Plot, CurveScatterPlot]
         if self.task is not None and self.task.window is not None:
             # This is skipped if the current class is instantiated outside
             # of an application (e.g. specific tests)

--- a/force_wfmanager/ui/review/tests/test_curve_scatter_plot.py
+++ b/force_wfmanager/ui/review/tests/test_curve_scatter_plot.py
@@ -36,7 +36,7 @@ class TestCurveScatterPlot(TestCase):
 
     def test_axis_hgroup_default(self):
         self.assertListEqual(
-            ['x', 'y', 'toggle_automatic_update',
+            ['x', 'y', 'color_options', 'toggle_automatic_update',
              'toggle_display_curve', '_curve_error'],
             item_info_from_group(self.plot.axis_hgroup.content))
 

--- a/force_wfmanager/ui/review/tests/test_curve_scatter_plot.py
+++ b/force_wfmanager/ui/review/tests/test_curve_scatter_plot.py
@@ -1,0 +1,92 @@
+from unittest import TestCase, mock
+
+from chaco.api import ArrayPlotData
+from chaco.api import Plot as ChacoPlot
+
+from force_wfmanager.model.analysis_model import AnalysisModel
+from force_wfmanager.ui.review.curve_scatter_plot import CurveScatterPlot
+
+
+class TestCurveScatterPlot(TestCase):
+
+    def setUp(self):
+        self.analysis_model = AnalysisModel(
+            header=['parameter_1', 'parameter_2',
+                    'salt', 'kpi_1'],
+            _evaluation_steps=[('A', 1.45, 0.5, 10),
+                               ('A', 5.11, 1.0, 12),
+                               ('B', 4.999, 1.1, 17),
+                               ('B', 4.998, 2.0, 22)]
+        )
+        self.plot = CurveScatterPlot(
+            analysis_model=self.analysis_model
+        )
+
+    def test_init(self):
+        self.assertEqual("", self.plot.x)
+        self.assertEqual("", self.plot.y)
+        self.plot._update_plot()
+        self.assertListEqual(
+            [], self.plot._plot_data.get_data("x_curve").tolist())
+        self.assertListEqual(
+            [], self.plot._plot_data.get_data("y_curve").tolist())
+        self.assertTrue(self.plot.plot_updater.active)
+        self.assertTrue(self.plot.toggle_automatic_update)
+
+    def test_add_curve(self):
+        self.assertIsNone(self.plot._curve_axis)
+        plot_data = ArrayPlotData()
+        plot_data.set_data("x_curve", [])
+        plot_data.set_data("y_curve", [])
+        plot = ChacoPlot(plot_data)
+
+        self.plot._add_curve(plot)
+        self.assertIsNotNone(self.plot._curve_axis)
+
+    def test_initialize_chaco_plots(self):
+        self.assertIsNone(self.plot._curve_axis)
+        self.plot.plot_scatter()
+        self.assertIsNotNone(self.plot._curve_axis)
+
+    def test_plot_data_default(self):
+        self.assertIn('x_curve', self.plot._plot_data.arrays)
+        self.assertIn('y_curve', self.plot._plot_data.arrays)
+
+    def test_update_curve_plot(self):
+        self.assertFalse(self.plot.toggle_display_curve)
+        self.plot._update_curve_plot()
+        self.assertTrue(self.plot._curve_status)
+        self.assertEqual(
+            0, len(self.plot._plot_data.get_data("x_curve")))
+        self.assertEqual(
+            0, len(self.plot._plot_data.get_data("y_curve")))
+
+        self.plot.x = 'parameter_2'
+        self.plot.y = 'kpi_1'
+
+        self.plot.toggle_display_curve = True
+        self.assertEqual(
+            20, len(self.plot._plot_data.get_data("x_curve")))
+        self.assertEqual(
+            20, len(self.plot._plot_data.get_data("y_curve")))
+        self.assertTrue(self.plot._curve_status)
+
+        self.plot.x = ""
+        self.plot._update_curve_plot()
+        self.assertEqual(
+            0, len(self.plot._plot_data.get_data("x_curve")))
+        self.assertEqual(
+            0, len(self.plot._plot_data.get_data("y_curve")))
+
+        def raise_error(*args, **kwargs):
+            raise ValueError
+
+        self.plot.x = "parameter_2"
+        with mock.patch('scipy.interpolate.interp1d',
+                        side_effect=raise_error):
+            self.plot._update_curve_plot()
+            self.assertEqual(
+                0, len(self.plot._plot_data.get_data("x_curve")))
+            self.assertEqual(
+                0, len(self.plot._plot_data.get_data("y_curve")))
+            self.assertFalse(self.plot._curve_status)

--- a/force_wfmanager/ui/review/tests/test_curve_scatter_plot.py
+++ b/force_wfmanager/ui/review/tests/test_curve_scatter_plot.py
@@ -4,6 +4,7 @@ from chaco.api import ArrayPlotData
 from chaco.api import Plot as ChacoPlot
 
 from force_wfmanager.model.analysis_model import AnalysisModel
+from force_wfmanager.ui.ui_utils import item_info_from_group
 from force_wfmanager.ui.review.curve_scatter_plot import CurveScatterPlot
 
 
@@ -32,6 +33,12 @@ class TestCurveScatterPlot(TestCase):
             [], self.plot._plot_data.get_data("y_curve").tolist())
         self.assertTrue(self.plot.plot_updater.active)
         self.assertTrue(self.plot.toggle_automatic_update)
+
+    def test_axis_hgroup_default(self):
+        self.assertListEqual(
+            ['x', 'y', 'toggle_automatic_update',
+             'toggle_display_curve', '_curve_error'],
+            item_info_from_group(self.plot.axis_hgroup.content))
 
     def test_add_curve(self):
         self.assertIsNone(self.plot._curve_axis)

--- a/force_wfmanager/ui/review/tests/test_data_view_pane.py
+++ b/force_wfmanager/ui/review/tests/test_data_view_pane.py
@@ -7,6 +7,7 @@ import unittest
 from force_wfmanager.model.analysis_model import AnalysisModel
 from force_wfmanager.ui.review.data_view_pane import DataViewPane
 from force_wfmanager.ui.review.plot import Plot
+from force_wfmanager.ui.review.curve_scatter_plot import CurveScatterPlot
 
 
 DATA_VIEW_PANE_EDIT_TRAITS_PATH = (
@@ -45,10 +46,11 @@ class TestDataViewPane(unittest.TestCase):
 
     def test_load_and_set_default_data_views(self):
         # This test class doesn't test the application, so there is no
-        # plugin discovery. One default plot will be found as it's the only
-        # one which is automatically populated.
+        # plugin discovery. Two default plots will be found as they are the
+        # only ones that are automatically populated.
         self.assertIn(Plot, self.pane.available_data_views)
-        self.assertEqual(len(self.pane.available_data_views), 1)
+        self.assertIn(CurveScatterPlot, self.pane.available_data_views)
+        self.assertEqual(len(self.pane.available_data_views), 2)
 
     def test_data_view_descriptions(self):
         # the "change" button needs to be fired to populate the descriptions

--- a/force_wfmanager/ui/ui_utils.py
+++ b/force_wfmanager/ui/ui_utils.py
@@ -27,7 +27,7 @@ def model_info(model):
     main_group_contents = current_view.content.content
 
     # Names of all traits with a representation in the view
-    view_info = _item_info_from_group(main_group_contents)
+    view_info = item_info_from_group(main_group_contents)
 
     # Remove any non-visible traits
     interactive_view_info = [
@@ -38,7 +38,7 @@ def model_info(model):
     return interactive_view_info
 
 
-def _item_info_from_group(group_contents, item_info=None):
+def item_info_from_group(group_contents, item_info=None):
     """Gets the item names from a list of groups (group_contents).
     Returns a list of trait names corresponding to the items in the group.
     """
@@ -46,7 +46,7 @@ def _item_info_from_group(group_contents, item_info=None):
         item_info = []
     for entity in group_contents:
         if isinstance(entity, Group):
-            item_info = _item_info_from_group(entity.content, item_info)
+            item_info = item_info_from_group(entity.content, item_info)
         elif isinstance(entity, Item):
             item_info.append(entity.name)
     return item_info


### PR DESCRIPTION
## Description

Adds a new `BaseDataView` to the default plot types available, which is a scatter plot that displays an (optional) fitted curve through the 2D data points

### Summary
Includes `CurveScatterPlot` class, which is selectable by default in the UI.

Some refactoring is also performed to enable easy inheritance between `Plot` and `CurveScatterPlot` classes.

### Future Work
At the moment a simple interpolation is performed between data points, which does not work very well for noisy data. We should consider using a more complex fitting, such as BSplines, in the future

Additionally, refactoring the `BasePlot` classes to not inherit, but extend features of the scatter plot would be a better architecture. Some mixin system would therefore be desirable.

### Notes
- We may want to only include one plot by default, since the curve display is optional but for now the `WfManager` has both the color and curve scatter plots

## Changes
- New feature: scatter plot with curve fitting in data viewer
