### PR TITLE
DEV: Support metadata being reported to the AnalaysisModel

### DIFF
--- a/force_wfmanager/model/analysis_model.py
+++ b/force_wfmanager/model/analysis_model.py
@@ -286,8 +286,17 @@ class AnalysisModel(HasStrictTraits):
                     f"be skipped in the AnalysisModel."
                 )
             else:
-                self.notify(step[1], metadata=True)
-                self.notify(step[0])
+                # TODO: This format is now deprecated and should be removed
+                #  in version 0.7.0
+                #  https://github.com/force-h2020/force-wfmanager/issues/414
+                if isinstance(step, list):
+                    log.warning(
+                        'Project file format is deprecated and will be removed'
+                        ' in version 0.7.0')
+                    self.notify(step)
+                else:
+                    self.notify(step['metadata'], metadata=True)
+                    self.notify(step['data'])
 
     def to_json(self):
         """ Returns a dictionary representation with column names as keys
@@ -307,7 +316,7 @@ class AnalysisModel(HasStrictTraits):
         data = {"header": self.header}
         for index, row in enumerate(self.evaluation_steps, start=1):
             metadata = self.step_metadata[index-1]
-            data[index] = (row, metadata)
+            data[index] = {'data': row, 'metadata': metadata}
 
         return data
 

--- a/force_wfmanager/model/analysis_model.py
+++ b/force_wfmanager/model/analysis_model.py
@@ -34,14 +34,23 @@ class AnalysisModel(HasStrictTraits):
     #: `_row_data` first, before the whole row is added to the model table.
     _row_data = Dict(key_trait=Str)
 
+    #: Storage for any metadata that is received along with the MCO data
+    _row_metadata = Dict(key_trait=Str)
+
     #: Private trait of the `evaluation_steps` property
     _evaluation_steps = List(Tuple())
+
+    #: Private trait of the `_step_metadata` property
+    _step_metadata = List(Dict())
 
     #: Evaluation steps, each evaluation step is a tuple of parameter values,
     #: received from the a single Workflow execution. The order of
     #: the parameters in each evaluation step must match the order of
     #: value_names
     evaluation_steps = Property(List(Tuple()), depends_on="_evaluation_steps")
+
+    #: Metadata associated with each evaluation step
+    step_metadata = Property(List(Dict()), depends_on="_step_metadata")
 
     #: Tracks whether the current state of AnalysisModel can be exported
     _export_enabled = Bool(False)
@@ -67,8 +76,14 @@ class AnalysisModel(HasStrictTraits):
     def _row_data_default(self):
         return dict.fromkeys(self.header)
 
+    def _row_metadata_default(self):
+        return {}
+
     def _get_export_enabled(self):
         return self._export_enabled
+
+    def _get_step_metadata(self):
+        return self._step_metadata
 
     def _get_evaluation_steps(self):
         return self._evaluation_steps
@@ -97,14 +112,17 @@ class AnalysisModel(HasStrictTraits):
     def _get_is_empty(self):
         return not bool(len(self.evaluation_steps))
 
-    def notify(self, data):
+    def notify(self, data, metadata=False):
         """ Public method to add `data` to the AnalysisModel.
         If no `header` is set up, the `data` is considered to be a
-        `header`. Otherwise, the `data` is treated as to be added to
-        the current row.
+        `header`. If the metadata keyword is set to True the `data` is
+        treated as metadata to be associated with the current row.
+        Otherwise, the `data` is treated as to be added to the current row.
         """
         if not self.header:
             self._add_header(data)
+        elif metadata:
+            self._add_metadata(data)
         else:
             self._add_data(data)
 
@@ -136,6 +154,16 @@ class AnalysisModel(HasStrictTraits):
             self._add_cells(data)
             self._finalize_row()
 
+    def _add_metadata(self, data):
+        """ For each evaluation step, add optional metadata. Expects
+        the `data` attribute to be a dictionary containing key value
+        pairs to be associated with the current row.
+        """
+        try:
+            self._row_metadata.update(data)
+        except (TraitError, TypeError, ValueError):
+            pass
+
     def _add_cell(self, label, value):
         """ Inserts a `value` into the column of the current row
         (self.row_data) with the `label` label."""
@@ -160,8 +188,12 @@ class AnalysisModel(HasStrictTraits):
         row_data = tuple(
             self._row_data.get(label, None) for label in self.header
         )
+
         self._add_evaluation_step(row_data)
+        self._step_metadata.append(self._row_metadata)
+
         self._row_data = self._row_data_default()
+        self._row_metadata = self._row_metadata_default()
 
     @on_trait_change("header")
     def clear_steps(self):
@@ -170,6 +202,7 @@ class AnalysisModel(HasStrictTraits):
         :attr:`value_names`
         """
         self._evaluation_steps[:] = []
+        self._step_metadata[:] = []
         self._selected_step_indices = None
         self._export_enabled = False
 
@@ -253,7 +286,8 @@ class AnalysisModel(HasStrictTraits):
                     f"be skipped in the AnalysisModel."
                 )
             else:
-                self.notify(step)
+                self.notify(step[1], metadata=True)
+                self.notify(step[0])
 
     def to_json(self):
         """ Returns a dictionary representation with column names as keys
@@ -272,7 +306,8 @@ class AnalysisModel(HasStrictTraits):
         """
         data = {"header": self.header}
         for index, row in enumerate(self.evaluation_steps, start=1):
-            data[index] = row
+            metadata = self.step_metadata[index-1]
+            data[index] = (row, metadata)
 
         return data
 
@@ -287,7 +322,9 @@ class AnalysisModel(HasStrictTraits):
             )
 
     def dump_json(self, filename, *, mode="w"):
-        """ Writes the AnalysisModel to a `filename` file in json format."""
+        """ Writes the AnalysisModel to a `filename` file in json format,
+        including both data and metadata values. Can be used to save the
+        state of the analysis."""
         if not self.export_enabled:
             return False
 
@@ -296,7 +333,11 @@ class AnalysisModel(HasStrictTraits):
         return True
 
     def dump_csv(self, filename, *, mode="w"):
-        """ Writes the AnalysisModel to a `filename` file in csv format."""
+        """ Writes the AnalysisModel to a `filename` file in csv format,
+        but does not include metadata values. Should be only be used to
+        export MCO parameter and KPI data, rather than saving the state
+        of the analysis.
+        """
         if not self.export_enabled:
             return False
 

--- a/force_wfmanager/model/tests/test_analysis_model.py
+++ b/force_wfmanager/model/tests/test_analysis_model.py
@@ -14,6 +14,14 @@ from force_wfmanager.model.analysis_model import AnalysisModel
 class TestAnalysisModel(TestCase):
     def setUp(self):
         self.model = AnalysisModel()
+        self.header = ("a", "b", "c")
+        self.data = ((1, 2, 3), (4, 5, 6))
+        self.metadata = ({}, {'d': 10})
+        self.state_dict = {
+            "header": self.header,
+            "1": (self.data[0], self.metadata[0]),
+            "2": (self.data[1], self.metadata[1])
+        }
 
     def test_initialize(self):
         self.assertEqual(tuple(), self.model.header)
@@ -24,10 +32,10 @@ class TestAnalysisModel(TestCase):
         self.assertDictEqual(self.model._row_data, {})
 
     def test__add_header(self):
-        header = ("a", "b", "c")
-        self.model._add_header(header)
-        self.assertTupleEqual(self.model.header, header)
-        self.assertDictEqual(self.model._row_data, dict.fromkeys(header))
+        self.model._add_header(self.header)
+        self.assertTupleEqual(self.header, self.model.header)
+        self.assertDictEqual(
+            dict.fromkeys(self.header), self.model._row_data)
 
         wrong_header = 1
         log_error = (
@@ -42,19 +50,16 @@ class TestAnalysisModel(TestCase):
         )
 
     def test_header_update(self):
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, "1": data[0], "2": data[1]}
-        self.model.from_json(state_dict)
+        self.model.from_json(self.state_dict)
 
-        self.assertTupleEqual(self.model.header, header)
+        self.assertTupleEqual(self.model.header, self.header)
         self.model.header = ("new", )
         self.assertTupleEqual(self.model.header, ("new", ))
         self.assertEqual([], self.model.evaluation_steps)
+        self.assertEqual([], self.model.step_metadata)
 
     def test__add_cell(self):
-        header = ("a", "b", "c")
-        self.model._add_header(header)
+        self.model._add_header(self.header)
 
         self.model._add_cell(label="a", value="1")
         self.assertEqual("1", self.model._row_data["a"])
@@ -80,8 +85,7 @@ class TestAnalysisModel(TestCase):
         self.assertIsNone(self.model._row_data["c"])
 
     def test__add_cells(self):
-        header = ("a", "b", "c")
-        self.model._add_header(header)
+        self.model._add_header(self.header)
 
         data = []
         self.model._add_cells(data)
@@ -102,26 +106,40 @@ class TestAnalysisModel(TestCase):
         self.assertEqual(3, self.model._row_data["c"])
 
     def test_finalize_row(self):
-        header = ("a", "b", "c")
-        self.model._add_header(header)
+        self.model._add_header(self.header)
         data = (1, 2, 3)
         self.model._add_cells(data)
 
         self.model._finalize_row()
         self.assertEqual(1, len(self.model.evaluation_steps))
-        self.assertTupleEqual(self.model.evaluation_steps[0], data)
+        self.assertEqual(1, len(self.model.step_metadata))
+
+        self.assertTupleEqual(data, self.model.evaluation_steps[0])
+        self.assertDictEqual({}, self.model.step_metadata[0])
+
         self.assertDictEqual(
             self.model._row_data, self.model._row_data_default()
+        )
+        self.assertDictEqual(
+            self.model._row_metadata, self.model._row_metadata_default()
         )
 
         data = (1, 2)
         self.model._add_cells(data)
+        self.model._add_metadata({'extra': 7})
 
         self.model._finalize_row()
         self.assertEqual(2, len(self.model.evaluation_steps))
-        self.assertTupleEqual(self.model.evaluation_steps[1], (1, 2, None))
+        self.assertEqual(2, len(self.model.step_metadata))
+
+        self.assertTupleEqual((1, 2, None), self.model.evaluation_steps[1])
+        self.assertDictEqual({'extra': 7}, self.model.step_metadata[1])
+
         self.assertDictEqual(
             self.model._row_data, self.model._row_data_default()
+        )
+        self.assertDictEqual(
+            self.model._row_metadata, self.model._row_metadata_default()
         )
 
     def test__add_data(self):
@@ -138,15 +156,30 @@ class TestAnalysisModel(TestCase):
             model._add_data(["data", "entries"])
         mock_cells.assert_called_with(["data", "entries"])
 
-        header = ("a", "b", "c")
-        self.model._add_header(header)
+        self.model._add_header(self.header)
         self.model._add_data({"a": 1})
         self.model._add_data({"c": 2})
         self.model._add_data([3, 4])
         self.assertEqual(1, len(self.model.evaluation_steps))
-        self.assertTupleEqual(self.model.evaluation_steps[0], (3, 4, 2))
+        self.assertTupleEqual((3, 4, 2), self.model.evaluation_steps[0])
         self.assertDictEqual(
             self.model._row_data, self.model._row_data_default()
+        )
+
+    def test__add_metadata(self):
+        self.model._add_metadata({"a": 1})
+        self.assertDictEqual(
+            {"a": 1}, self.model._row_metadata
+        )
+
+        self.model._add_metadata({"a": 1, "c": 2})
+        self.assertDictEqual(
+            {"a": 1, "c": 2}, self.model._row_metadata
+        )
+
+        self.model._add_metadata([(3, 2, 5)])
+        self.assertDictEqual(
+            {"a": 1, "c": 2}, self.model._row_metadata
         )
 
     def test__add_evaluation_step(self):
@@ -179,6 +212,8 @@ class TestAnalysisModel(TestCase):
         with mock.patch.object(
             AnalysisModel, "_add_header"
         ) as mock_header, mock.patch.object(
+            AnalysisModel, "_add_metadata"
+        ) as mock_metadata, mock.patch.object(
             AnalysisModel, "_add_data"
         ) as mock_data:
             model = AnalysisModel()
@@ -186,15 +221,14 @@ class TestAnalysisModel(TestCase):
             # This line is necessary because the header must be set
             # in order to add data to the model.
             model.header = ("",)
+            model.notify(None, metadata=True)
             model.notify(None)
         mock_header.assert_called_once()
+        mock_metadata.assert_called_once()
         mock_data.assert_called_once()
 
     def test_column(self):
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, "1": data[0], "2": data[1]}
-        self.model.from_json(state_dict)
+        self.model.from_json(self.state_dict)
 
         column_by_id = self.model.column(0)
         column_by_label = self.model.column("a")
@@ -222,41 +256,38 @@ class TestAnalysisModel(TestCase):
 
     def test_is_empty(self):
         self.assertTrue(self.model.is_empty)
-
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, "1": data[0], "2": data[1]}
-        self.model.from_json(state_dict)
+        self.model.from_json(self.state_dict)
 
         self.assertFalse(self.model.is_empty)
 
     def test___getstate__(self):
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, 1: data[0], 2: data[1]}
-        self.model.notify(header)
-        for entry in data:
+        self.model.notify(self.header)
+        for entry, meta in zip(self.data, self.metadata):
+            self.model.notify(meta, metadata=True)
             self.model.notify(entry)
 
         state = self.model.__getstate__()
-        self.assertDictEqual(state, state_dict)
+        self.assertDictEqual({
+            "header": self.header,
+            1: (self.data[0], self.metadata[0]),
+            2: (self.data[1], self.metadata[1])},
+            state
+        )
 
         with mock.patch.object(AnalysisModel, "__getstate__") as mock_getstate:
             AnalysisModel().to_json()
         mock_getstate.assert_called_once()
 
     def test_json(self):
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, "1": data[0], "2": data[1]}
-
         error = (
             "AnalysisModel can't be instantiated from a data dictionary"
             " that does not contain a header."
         )
         with LogCapture() as capture:
             with self.assertRaisesRegex(KeyError, error):
-                AnalysisModel().from_json({"1": data[0], "2": data[1]})
+                AnalysisModel().from_json(
+                    {"1": (self.data[0], self.metadata[0]),
+                     "2": (self.data[1], self.metadata[1])})
         capture.check(
             (
                 "force_wfmanager.model.analysis_model",
@@ -268,14 +299,17 @@ class TestAnalysisModel(TestCase):
 
         with mock.patch.object(AnalysisModel, "clear") as mock_clear:
             model = AnalysisModel()
-            model.from_json(state_dict)
+            model.from_json(self.state_dict)
         mock_clear.assert_called_once()
 
-        self.model.from_json(state_dict)
-        self.assertTupleEqual(self.model.header, header)
+        self.model.from_json(self.state_dict)
+        self.assertTupleEqual(self.model.header, self.header)
         self.assertEqual(2, len(self.model.evaluation_steps))
-        self.assertTupleEqual(self.model.evaluation_steps[0], data[0])
-        self.assertTupleEqual(self.model.evaluation_steps[1], data[1])
+        self.assertEqual(2, len(self.model.step_metadata))
+        self.assertTupleEqual(self.data[0], self.model.evaluation_steps[0])
+        self.assertDictEqual(self.metadata[0], self.model.step_metadata[0])
+        self.assertTupleEqual(self.data[1], self.model.evaluation_steps[1])
+        self.assertDictEqual(self.metadata[1], self.model.step_metadata[1])
 
         tmp_file = tempfile.NamedTemporaryFile()
         filename = tmp_file.name
@@ -283,16 +317,20 @@ class TestAnalysisModel(TestCase):
         with open(filename) as f:
             json_data = json.load(f)
         self.assertDictEqual(
-            json_data,
-            {"header": list(header), "1": list(data[0]), "2": list(data[1])},
+            {"header": list(self.header),
+             "1": [list(self.data[0]), self.metadata[0]],
+             "2": [list(self.data[1]), self.metadata[1]]},
+            json_data
         )
 
         self.model._export_enabled = False
         self.assertFalse(self.model.dump_json(None))
 
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, "1": data[0], "3": data[1]}
+        state_dict = {
+            "header": self.header,
+            "1": (self.data[0], self.metadata[0]),
+            "3": (self.data[1], self.metadata[1])
+        }
         with LogCapture() as capture:
             AnalysisModel().from_json(state_dict)
         capture.check(
@@ -305,10 +343,7 @@ class TestAnalysisModel(TestCase):
         )
 
     def test_write_csv(self):
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        state_dict = {"header": header, "1": data[0], "2": data[1]}
-        self.model.from_json(state_dict)
+        self.model.from_json(self.state_dict)
         tmp_file = tempfile.NamedTemporaryFile()
         filename = tmp_file.name
         self.model.dump_csv(filename)
@@ -334,33 +369,32 @@ class TestAnalysisModel(TestCase):
             AnalysisModel().write("filename.format")
 
     def test_clear(self):
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        self.model.notify(header)
-        for entry in data:
+        self.model.notify(self.header)
+        for entry, meta in zip(self.data, self.metadata):
+            self.model.notify(meta, metadata=True)
             self.model.notify(entry)
 
         self.model.clear_steps()
         self.assertFalse(self.model.export_enabled)
         self.assertEqual([], self.model.evaluation_steps)
-        self.assertTupleEqual(self.model.header, header)
+        self.assertEqual([], self.model.step_metadata)
+        self.assertTupleEqual(self.model.header, self.header)
 
-        self.model.notify(header)
-        for entry in data:
+        self.model.notify(self.header)
+        for entry in self.data:
             self.model.notify(entry)
 
         self.model.clear()
         self.assertFalse(self.model.export_enabled)
         self.assertEqual([], self.model.evaluation_steps)
+        self.assertEqual([], self.model.step_metadata)
         self.assertTupleEqual(self.model.header, ())
 
     def test_selected_step_indices(self):
         self.assertIsNone(self.model.selected_step_indices)
 
-        header = ("a", "b", "c")
-        data = ((1, 2, 3), (4, 5, 6))
-        self.model.notify(header)
-        for entry in data:
+        self.model.notify(self.header)
+        for entry in self.data:
             self.model.notify(entry)
 
         self.assertIsNone(self.model.selected_step_indices)

--- a/force_wfmanager/model/tests/test_analysis_model.py
+++ b/force_wfmanager/model/tests/test_analysis_model.py
@@ -20,7 +20,7 @@ class TestAnalysisModel(TestCase):
         self.state_dict = {
             "header": self.header,
             "1": {'data': self.data[0],
-                  'metadata':self.metadata[0]},
+                  'metadata': self.metadata[0]},
             "2": {'data': self.data[1],
                   'metadata': self.metadata[1]}
         }

--- a/force_wfmanager/model/tests/test_analysis_model.py
+++ b/force_wfmanager/model/tests/test_analysis_model.py
@@ -373,8 +373,8 @@ class TestAnalysisModel(TestCase):
             self.assertDictEqual(
                 {
                     "header": self.header,
-                    "1": {"data": list(self.data[0]),
-                          "metadata": {}}
+                    1: {"data": self.data[0],
+                        "metadata": {}}
                 }, model.__getstate__())
 
     def test_write_csv(self):

--- a/force_wfmanager/tests/dummy_classes/dummy_events.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_events.py
@@ -1,0 +1,10 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
+from force_bdss.api import MCORuntimeEvent, UIEventMixin
+
+
+class ProbeUIRuntimeEvent(MCORuntimeEvent, UIEventMixin):
+
+    def serialize(self):
+        return []

--- a/force_wfmanager/tests/dummy_classes/dummy_events.py
+++ b/force_wfmanager/tests/dummy_classes/dummy_events.py
@@ -7,4 +7,4 @@ from force_bdss.api import MCORuntimeEvent, UIEventMixin
 class ProbeUIRuntimeEvent(MCORuntimeEvent, UIEventMixin):
 
     def serialize(self):
-        return []
+        return {'some_metadata': 0}

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -291,7 +291,15 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             1, len(self.setup_task.analysis_model.evaluation_steps)
         )
         self.assertEqual(
+            (1.0, 2.0),
+             self.setup_task.analysis_model.evaluation_steps[0]
+        )
+        self.assertEqual(
             1, len(self.setup_task.analysis_model.step_metadata)
+        )
+        self.assertDictEqual(
+            {'some_metadata': 0},
+            self.setup_task.analysis_model.step_metadata[0]
         )
 
     def test_initialize_finalize(self):

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -292,7 +292,7 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
         )
         self.assertEqual(
             (1.0, 2.0),
-             self.setup_task.analysis_model.evaluation_steps[0]
+            self.setup_task.analysis_model.evaluation_steps[0]
         )
         self.assertEqual(
             1, len(self.setup_task.analysis_model.step_metadata)

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -12,7 +12,6 @@ from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from force_bdss.api import (
     DataValue,
     MCOProgressEvent,
-    MCORuntimeEvent,
     MCOStartEvent,
     WorkflowWriter,
     plugin_id,
@@ -26,8 +25,10 @@ from force_wfmanager.tests.dummy_classes.dummy_contributed_ui import (
     DummyContributedUI2,
 )
 from force_wfmanager.tests.dummy_classes.dummy_wfmanager import (
-    DummyUIWfManager,
+    DummyUIWfManager
 )
+from force_wfmanager.tests.dummy_classes.dummy_events import (
+    ProbeUIRuntimeEvent)
 from force_wfmanager.tests.utils import wait_condition
 
 from .mock_methods import (
@@ -275,7 +276,7 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
 
         with self.event_loop():
             send_event(
-                MCORuntimeEvent()
+                ProbeUIRuntimeEvent()
             )
 
         with self.event_loop():

--- a/force_wfmanager/tests/test_wfmanager_setup_task.py
+++ b/force_wfmanager/tests/test_wfmanager_setup_task.py
@@ -12,6 +12,7 @@ from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from force_bdss.api import (
     DataValue,
     MCOProgressEvent,
+    MCORuntimeEvent,
     MCOStartEvent,
     WorkflowWriter,
     plugin_id,
@@ -263,11 +264,19 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             send_event(MCOStartEvent(parameter_names=["x"], kpi_names=["y"]))
 
         self.assertEqual(
-            len(self.setup_task.analysis_model.evaluation_steps), 0
+            0, len(self.setup_task.analysis_model.evaluation_steps)
         )
         self.assertEqual(
-            self.setup_task.analysis_model.header, ("x", "y")
+            0, len(self.setup_task.analysis_model.step_metadata)
         )
+        self.assertEqual(
+            ("x", "y"), self.setup_task.analysis_model.header
+        )
+
+        with self.event_loop():
+            send_event(
+                MCORuntimeEvent()
+            )
 
         with self.event_loop():
             send_event(
@@ -278,7 +287,10 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             )
 
         self.assertEqual(
-            len(self.setup_task.analysis_model.evaluation_steps), 1
+            1, len(self.setup_task.analysis_model.evaluation_steps)
+        )
+        self.assertEqual(
+            1, len(self.setup_task.analysis_model.step_metadata)
         )
 
     def test_initialize_finalize(self):

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -266,7 +266,8 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
             mock_json.return_value = {
                 "analysis_model": {
                     "header": ["x", "y"],
-                    "1": [[1, 2], {'a': 7}]
+                    "1": {'data': [1, 2],
+                          'metadata': {'a': 7}}
                 },
                 "version": "1",
                 "workflow": {},

--- a/force_wfmanager/tests/test_wfmanager_tasks.py
+++ b/force_wfmanager/tests/test_wfmanager_tasks.py
@@ -264,7 +264,10 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
 
             mock_file_dialog.side_effect = mock_dialog(FileDialog, OK)
             mock_json.return_value = {
-                "analysis_model": {"header": ["x", "y"], "1": [1, 2]},
+                "analysis_model": {
+                    "header": ["x", "y"],
+                    "1": [[1, 2], {'a': 7}]
+                },
                 "version": "1",
                 "workflow": {},
             }
@@ -300,10 +303,13 @@ class TestWFManagerTasks(GuiTestAssistant, TestCase):
                 old_analysis.header, self.setup_task.analysis_model.header
             )
             self.assertEqual(
-                self.review_task.analysis_model.header, ("x", "y")
+                ("x", "y"), self.review_task.analysis_model.header
             )
             self.assertEqual(
-                self.review_task.analysis_model.evaluation_steps, [(1, 2)]
+                [(1, 2)], self.review_task.analysis_model.evaluation_steps,
+            )
+            self.assertEqual(
+                [{'a': 7}], self.review_task.analysis_model.step_metadata
             )
             self.assertEqual(
                 self.setup_task.analysis_model.header,

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -424,12 +424,14 @@ class WfManagerSetupTask(Task):
             self.analysis_model.clear()
             self.computation_running = True
 
-        event_data = event.serialize()
-
-        if isinstance(event, MCORuntimeEvent):
-            self.analysis_model.notify(event_data, metadata=True)
-        elif isinstance(event, (MCOStartEvent, MCOProgressEvent)):
-            self.analysis_model.notify(event_data)
+        if isinstance(
+            event, (MCOStartEvent, MCOProgressEvent, MCORuntimeEvent)
+        ):
+            event_data = event.serialize()
+            self.analysis_model.notify(
+                event_data,
+                metadata=isinstance(event, MCORuntimeEvent)
+            )
 
     # Error Display
     def _show_error_dialog(self, message):

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -423,9 +423,10 @@ class WfManagerSetupTask(Task):
         if isinstance(event, MCOStartEvent):
             self.analysis_model.clear()
             self.computation_running = True
-        if isinstance(
-            event, (MCOStartEvent, MCOProgressEvent, MCORuntimeEvent)
-        ):
+        if isinstance(event, MCORuntimeEvent):
+            event_data = event.serialize()
+            self.analysis_model.notify(event_data, metadata=True)
+        if isinstance(event, (MCOStartEvent, MCOProgressEvent)):
             event_data = event.serialize()
             self.analysis_model.notify(event_data)
 

--- a/force_wfmanager/wfmanager_setup_task.py
+++ b/force_wfmanager/wfmanager_setup_task.py
@@ -416,18 +416,19 @@ class WfManagerSetupTask(Task):
         Handles the event received by the server, dispatching its
         action appropriately according to the type.
         Note: All the decision making related to the AnalysisModel
-        should be done by the AnalysisModel, not the setup taks.
+        should be done by the AnalysisModel, not the setup task.
         The AnalysisModel should receive the event instance and process
         the events itself.
         """
         if isinstance(event, MCOStartEvent):
             self.analysis_model.clear()
             self.computation_running = True
+
+        event_data = event.serialize()
+
         if isinstance(event, MCORuntimeEvent):
-            event_data = event.serialize()
             self.analysis_model.notify(event_data, metadata=True)
-        if isinstance(event, (MCOStartEvent, MCOProgressEvent)):
-            event_data = event.serialize()
+        elif isinstance(event, (MCOStartEvent, MCOProgressEvent)):
             self.analysis_model.notify(event_data)
 
     # Error Display


### PR DESCRIPTION
## Description

Allows data sources to report metadata values to the `AnalaysisModel` for each MCO step. These are then accessible via the `step_metadata` attribute, which contains a list of dictionaries.

### Related Issues
Concerns https://github.com/force-h2020/force-bdss/issues/200

### Background
Each element of the workflow has the ability to report data to the WfManager via `BaseDriverEvents` that inherit from the `UIEventMixin` classs. However, the `AnalaysisModel` has not been able to store data that is reported during an evaluation of the Workflow, only that delieverd by a `MCOProgressEvent`, containing the parameters and KPIs.

### Summary
Provides the `AnalysisModel.step_metadata` dictionary trait to store metadata for each Workflow run and methods to ensure this is correctly populated during the calculation.

### Future Work
`BaseDataView` classes can now display data for each selected evaluation step. The base class should be updated with the framework to do so.

### Notes
- It is expected that metadata will be delivered to the WfManager by classes that inherit from `MCORuntimeEvent`. However, objects of this class on its own will not be sent by the BDSS, since they must also inherit from `UIEventMixin`. We may want to rethink this system, or provide a single base class for events containing metadata that will be sent to the WfManager
- ~This implementation will break the loading of any project files that have been saved containing analysis data. Considering this is very underused component of the WfManager, it is unlikely to cause issues for current users - we can always implement support for earlier versions of project files if needs be.~ Old project files are deprecated, but still supported (#414 )

## Changes
- `AnalysisModel` class now supports reporting of metadata during MCO run
