### PR TITLE
FIX: ScatterPlot not initializing with use_color_plot=True

### DIFF
--- a/force_wfmanager/ui/review/scatter_plot.py
+++ b/force_wfmanager/ui/review/scatter_plot.py
@@ -128,7 +128,7 @@ class ScatterPlot(BasePlot):
             _range = self._axis.color_mapper.range
             self._axis.color_mapper = cmap(_range)
 
-    @on_trait_change("use_color_plot")
+    @on_trait_change("use_color_plot", post_init=True)
     def change_plot_style(self):
         ranges = self._get_plot_range()
         x_title = self._plot.x_axis.title

--- a/force_wfmanager/ui/review/tests/test_scatter_plot.py
+++ b/force_wfmanager/ui/review/tests/test_scatter_plot.py
@@ -88,3 +88,10 @@ class TestScatterPlot(BasePlotTestCase):
         self.plot._reset_zoomtool(self.plot._plot)
         self.assertEqual(3, len(self.plot._plot.overlays))
         self.assertIsNot(old_tool, self.plot._plot.overlays[2])
+
+    def test_color_plot_init(self):
+        with self.subTest(
+                'Check that the scatter plot class can be '
+                'initialized as a color plot'):
+            plot = self.plot_cls(use_color_plot=True)
+            self.assertIsNotNone(plot._plot)


### PR DESCRIPTION
## Description

An exception was being thrown when calling `ScatterPlot(use_color_plot=True)`, which was caused by a trait listener that references `self._plot_data` being called before the init routine had assigned this trait.

### Summary
Including the `post_init=True` metadata on the problem listener (`ScatterPlot.change_plot_style`) resolves this issue. 

A unit test is also introduced to assert that the constructor can handle initializing `ScatterPlot(use_color_plot=True)`

## Changes
- Bugfix for ScatterPlot initialising class as a color plot
